### PR TITLE
[FE] 일별 플래너 API 연결

### DIFF
--- a/FE/package-lock.json
+++ b/FE/package-lock.json
@@ -18,6 +18,7 @@
         "axios": "^1.5.0",
         "css-loader": "^6.8.1",
         "dayjs": "^1.11.9",
+        "firebase": "^10.5.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-redux": "^8.1.2",
@@ -2289,6 +2290,500 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@firebase/analytics": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.10.0.tgz",
+      "integrity": "sha512-Locv8gAqx0e+GX/0SI3dzmBY5e9kjVDtD+3zCFLJ0tH2hJwuCAiL+5WkHuxKj92rqQj/rvkBUCfA1ewlX2hehg==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/installations": "0.6.4",
+        "@firebase/logger": "0.4.0",
+        "@firebase/util": "1.9.3",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics-compat": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.2.6.tgz",
+      "integrity": "sha512-4MqpVLFkGK7NJf/5wPEEP7ePBJatwYpyjgJ+wQHQGHfzaCDgntOnl9rL2vbVGGKCnRqWtZDIWhctB86UWXaX2Q==",
+      "dependencies": {
+        "@firebase/analytics": "0.10.0",
+        "@firebase/analytics-types": "0.8.0",
+        "@firebase/component": "0.6.4",
+        "@firebase/util": "1.9.3",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics-types": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.8.0.tgz",
+      "integrity": "sha512-iRP+QKI2+oz3UAh4nPEq14CsEjrjD6a5+fuypjScisAh9kXKFvdJOZJDwk7kikLvWVLGEs9+kIUS4LPQV7VZVw=="
+    },
+    "node_modules/@firebase/app": {
+      "version": "0.9.22",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.9.22.tgz",
+      "integrity": "sha512-4hbUg9ojPbn4Gj21Z/GnJbiLQYOzkwBDFT5vBkQgUJJGS28qQLG6eZZ1DwLKh8lcrNJc4MR90OPaJWhSzJCR2w==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/logger": "0.4.0",
+        "@firebase/util": "1.9.3",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/app-check": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.8.0.tgz",
+      "integrity": "sha512-dRDnhkcaC2FspMiRK/Vbp+PfsOAEP6ZElGm9iGFJ9fDqHoPs0HOPn7dwpJ51lCFi1+2/7n5pRPGhqF/F03I97g==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/logger": "0.4.0",
+        "@firebase/util": "1.9.3",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/app-check-compat": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.3.7.tgz",
+      "integrity": "sha512-cW682AxsyP1G+Z0/P7pO/WT2CzYlNxoNe5QejVarW2o5ZxeWSSPAiVEwpEpQR/bUlUmdeWThYTMvBWaopdBsqw==",
+      "dependencies": {
+        "@firebase/app-check": "0.8.0",
+        "@firebase/app-check-types": "0.5.0",
+        "@firebase/component": "0.6.4",
+        "@firebase/logger": "0.4.0",
+        "@firebase/util": "1.9.3",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/app-check-interop-types": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.3.0.tgz",
+      "integrity": "sha512-xAxHPZPIgFXnI+vb4sbBjZcde7ZluzPPaSK7Lx3/nmuVk4TjZvnL8ONnkd4ERQKL8WePQySU+pRcWkh8rDf5Sg=="
+    },
+    "node_modules/@firebase/app-check-types": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-types/-/app-check-types-0.5.0.tgz",
+      "integrity": "sha512-uwSUj32Mlubybw7tedRzR24RP8M8JUVR3NPiMk3/Z4bCmgEKTlQBwMXrehDAZ2wF+TsBq0SN1c6ema71U/JPyQ=="
+    },
+    "node_modules/@firebase/app-compat": {
+      "version": "0.2.22",
+      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.2.22.tgz",
+      "integrity": "sha512-kyksJFA19Oz5HZmR56s/ziOM6ivDBF9JYwC0ufacooYNd2sQ3pRsi5MZAYb1FR9hCE7MgoHuPmTtBHA7S/Cv8g==",
+      "dependencies": {
+        "@firebase/app": "0.9.22",
+        "@firebase/component": "0.6.4",
+        "@firebase/logger": "0.4.0",
+        "@firebase/util": "1.9.3",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/app-types": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.0.tgz",
+      "integrity": "sha512-AeweANOIo0Mb8GiYm3xhTEBVCmPwTYAu9Hcd2qSkLuga/6+j9b1Jskl5bpiSQWy9eJ/j5pavxj6eYogmnuzm+Q=="
+    },
+    "node_modules/@firebase/auth": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.3.2.tgz",
+      "integrity": "sha512-ksYpeRACL8INRpFZzbCLLnI9NP+L3UH/+ebKo4oBjhc/dSwPbpw6E1wjdm0odB1U5xHhXD/5lpyeFQZ+jXyBxA==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/logger": "0.4.0",
+        "@firebase/util": "1.9.3",
+        "node-fetch": "2.6.7",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@react-native-async-storage/async-storage": "^1.18.1"
+      },
+      "peerDependenciesMeta": {
+        "@react-native-async-storage/async-storage": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@firebase/auth-compat": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.4.8.tgz",
+      "integrity": "sha512-qKX8BOl1qewBzpfAXl6/lKPW7fjnY8/3umiSFIGO8SHwLQ3LsAdNFPdwafouwMiKLo5MXxW4XdxNSI4ilt0Z5w==",
+      "dependencies": {
+        "@firebase/auth": "1.3.2",
+        "@firebase/auth-types": "0.12.0",
+        "@firebase/component": "0.6.4",
+        "@firebase/util": "1.9.3",
+        "node-fetch": "2.6.7",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/auth-interop-types": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.2.1.tgz",
+      "integrity": "sha512-VOaGzKp65MY6P5FI84TfYKBXEPi6LmOCSMMzys6o2BN2LOsqy7pCuZCup7NYnfbk5OkkQKzvIfHOzTm0UDpkyg=="
+    },
+    "node_modules/@firebase/auth-types": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.12.0.tgz",
+      "integrity": "sha512-pPwaZt+SPOshK8xNoiQlK5XIrS97kFYc3Rc7xmy373QsOJ9MmqXxLaYssP5Kcds4wd2qK//amx/c+A8O2fVeZA==",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/component": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.6.4.tgz",
+      "integrity": "sha512-rLMyrXuO9jcAUCaQXCMjCMUsWrba5fzHlNK24xz5j2W6A/SRmK8mZJ/hn7V0fViLbxC0lPMtrK1eYzk6Fg03jA==",
+      "dependencies": {
+        "@firebase/util": "1.9.3",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/database": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.0.1.tgz",
+      "integrity": "sha512-VAhF7gYwunW4Lw/+RQZvW8dlsf2r0YYqV9W0Gi2Mz8+0TGg1mBJWoUtsHfOr8kPJXhcLsC4eP/z3x6L/Fvjk/A==",
+      "dependencies": {
+        "@firebase/auth-interop-types": "0.2.1",
+        "@firebase/component": "0.6.4",
+        "@firebase/logger": "0.4.0",
+        "@firebase/util": "1.9.3",
+        "faye-websocket": "0.11.4",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/database-compat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-1.0.1.tgz",
+      "integrity": "sha512-ky82yLIboLxtAIWyW/52a6HLMVTzD2kpZlEilVDok73pNPLjkJYowj8iaIWK5nTy7+6Gxt7d00zfjL6zckGdXQ==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/database": "1.0.1",
+        "@firebase/database-types": "1.0.0",
+        "@firebase/logger": "0.4.0",
+        "@firebase/util": "1.9.3",
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/database-types": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.0.tgz",
+      "integrity": "sha512-SjnXStoE0Q56HcFgNQ+9SsmJc0c8TqGARdI/T44KXy+Ets3r6x/ivhQozT66bMnCEjJRywYoxNurRTMlZF8VNg==",
+      "dependencies": {
+        "@firebase/app-types": "0.9.0",
+        "@firebase/util": "1.9.3"
+      }
+    },
+    "node_modules/@firebase/firestore": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.3.2.tgz",
+      "integrity": "sha512-K4TwMbgArWw+XAEUYX/vtk+TVy9n1uLeJKSrQeb89lwfkfyFINGLPME6YleaS0ovD1ziLM5/0WgL1CR4s53fDg==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/logger": "0.4.0",
+        "@firebase/util": "1.9.3",
+        "@firebase/webchannel-wrapper": "0.10.3",
+        "@grpc/grpc-js": "~1.9.0",
+        "@grpc/proto-loader": "^0.7.8",
+        "node-fetch": "2.6.7",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/firestore-compat": {
+      "version": "0.3.21",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.3.21.tgz",
+      "integrity": "sha512-u17so8cP4FQBEJyivAbZc0kW09YBXBvhSmUXiB7swkOLemfZUmmPZQGJxZGa9y/M02euU1y4EzvWN/h/bkx8pg==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/firestore": "4.3.2",
+        "@firebase/firestore-types": "3.0.0",
+        "@firebase/util": "1.9.3",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/firestore-types": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-3.0.0.tgz",
+      "integrity": "sha512-Meg4cIezHo9zLamw0ymFYBD4SMjLb+ZXIbuN7T7ddXN6MGoICmOTq3/ltdCGoDCS2u+H1XJs2u/cYp75jsX9Qw==",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/functions": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.10.0.tgz",
+      "integrity": "sha512-2U+fMNxTYhtwSpkkR6WbBcuNMOVaI7MaH3cZ6UAeNfj7AgEwHwMIFLPpC13YNZhno219F0lfxzTAA0N62ndWzA==",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.0",
+        "@firebase/auth-interop-types": "0.2.1",
+        "@firebase/component": "0.6.4",
+        "@firebase/messaging-interop-types": "0.2.0",
+        "@firebase/util": "1.9.3",
+        "node-fetch": "2.6.7",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/functions-compat": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.3.5.tgz",
+      "integrity": "sha512-uD4jwgwVqdWf6uc3NRKF8cSZ0JwGqSlyhPgackyUPe+GAtnERpS4+Vr66g0b3Gge0ezG4iyHo/EXW/Hjx7QhHw==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/functions": "0.10.0",
+        "@firebase/functions-types": "0.6.0",
+        "@firebase/util": "1.9.3",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/functions-types": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.6.0.tgz",
+      "integrity": "sha512-hfEw5VJtgWXIRf92ImLkgENqpL6IWpYaXVYiRkFY1jJ9+6tIhWM7IzzwbevwIIud/jaxKVdRzD7QBWfPmkwCYw=="
+    },
+    "node_modules/@firebase/installations": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.6.4.tgz",
+      "integrity": "sha512-u5y88rtsp7NYkCHC3ElbFBrPtieUybZluXyzl7+4BsIz4sqb4vSAuwHEUgCgCeaQhvsnxDEU6icly8U9zsJigA==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/util": "1.9.3",
+        "idb": "7.0.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/installations-compat": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-compat/-/installations-compat-0.2.4.tgz",
+      "integrity": "sha512-LI9dYjp0aT9Njkn9U4JRrDqQ6KXeAmFbRC0E7jI7+hxl5YmRWysq5qgQl22hcWpTk+cm3es66d/apoDU/A9n6Q==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/installations": "0.6.4",
+        "@firebase/installations-types": "0.5.0",
+        "@firebase/util": "1.9.3",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/installations-types": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.5.0.tgz",
+      "integrity": "sha512-9DP+RGfzoI2jH7gY4SlzqvZ+hr7gYzPODrbzVD82Y12kScZ6ZpRg/i3j6rleto8vTFC8n6Len4560FnV1w2IRg==",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x"
+      }
+    },
+    "node_modules/@firebase/installations/node_modules/idb": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-7.0.1.tgz",
+      "integrity": "sha512-UUxlE7vGWK5RfB/fDwEGgRf84DY/ieqNha6msMV99UsEMQhJ1RwbCd8AYBj3QMgnE3VZnfQvm4oKVCJTYlqIgg=="
+    },
+    "node_modules/@firebase/logger": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.4.0.tgz",
+      "integrity": "sha512-eRKSeykumZ5+cJPdxxJRgAC3G5NknY2GwEbKfymdnXtnT0Ucm4pspfR6GT4MUQEDuJwRVbVcSx85kgJulMoFFA==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/messaging": {
+      "version": "0.12.4",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.12.4.tgz",
+      "integrity": "sha512-6JLZct6zUaex4g7HI3QbzeUrg9xcnmDAPTWpkoMpd/GoSVWH98zDoWXMGrcvHeCAIsLpFMe4MPoZkJbrPhaASw==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/installations": "0.6.4",
+        "@firebase/messaging-interop-types": "0.2.0",
+        "@firebase/util": "1.9.3",
+        "idb": "7.0.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/messaging-compat": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.2.4.tgz",
+      "integrity": "sha512-lyFjeUhIsPRYDPNIkYX1LcZMpoVbBWXX4rPl7c/rqc7G+EUea7IEtSt4MxTvh6fDfPuzLn7+FZADfscC+tNMfg==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/messaging": "0.12.4",
+        "@firebase/util": "1.9.3",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/messaging-interop-types": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-interop-types/-/messaging-interop-types-0.2.0.tgz",
+      "integrity": "sha512-ujA8dcRuVeBixGR9CtegfpU4YmZf3Lt7QYkcj693FFannwNuZgfAYaTmbJ40dtjB81SAu6tbFPL9YLNT15KmOQ=="
+    },
+    "node_modules/@firebase/messaging/node_modules/idb": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-7.0.1.tgz",
+      "integrity": "sha512-UUxlE7vGWK5RfB/fDwEGgRf84DY/ieqNha6msMV99UsEMQhJ1RwbCd8AYBj3QMgnE3VZnfQvm4oKVCJTYlqIgg=="
+    },
+    "node_modules/@firebase/performance": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.6.4.tgz",
+      "integrity": "sha512-HfTn/bd8mfy/61vEqaBelNiNnvAbUtME2S25A67Nb34zVuCSCRIX4SseXY6zBnOFj3oLisaEqhVcJmVPAej67g==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/installations": "0.6.4",
+        "@firebase/logger": "0.4.0",
+        "@firebase/util": "1.9.3",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/performance-compat": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.2.4.tgz",
+      "integrity": "sha512-nnHUb8uP9G8islzcld/k6Bg5RhX62VpbAb/Anj7IXs/hp32Eb2LqFPZK4sy3pKkBUO5wcrlRWQa6wKOxqlUqsg==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/logger": "0.4.0",
+        "@firebase/performance": "0.6.4",
+        "@firebase/performance-types": "0.2.0",
+        "@firebase/util": "1.9.3",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/performance-types": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.2.0.tgz",
+      "integrity": "sha512-kYrbr8e/CYr1KLrLYZZt2noNnf+pRwDq2KK9Au9jHrBMnb0/C9X9yWSXmZkFt4UIdsQknBq8uBB7fsybZdOBTA=="
+    },
+    "node_modules/@firebase/remote-config": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.4.4.tgz",
+      "integrity": "sha512-x1ioTHGX8ZwDSTOVp8PBLv2/wfwKzb4pxi0gFezS5GCJwbLlloUH4YYZHHS83IPxnua8b6l0IXUaWd0RgbWwzQ==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/installations": "0.6.4",
+        "@firebase/logger": "0.4.0",
+        "@firebase/util": "1.9.3",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/remote-config-compat": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.2.4.tgz",
+      "integrity": "sha512-FKiki53jZirrDFkBHglB3C07j5wBpitAaj8kLME6g8Mx+aq7u9P7qfmuSRytiOItADhWUj7O1JIv7n9q87SuwA==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/logger": "0.4.0",
+        "@firebase/remote-config": "0.4.4",
+        "@firebase/remote-config-types": "0.3.0",
+        "@firebase/util": "1.9.3",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/remote-config-types": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.3.0.tgz",
+      "integrity": "sha512-RtEH4vdcbXZuZWRZbIRmQVBNsE7VDQpet2qFvq6vwKLBIQRQR5Kh58M4ok3A3US8Sr3rubYnaGqZSurCwI8uMA=="
+    },
+    "node_modules/@firebase/storage": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.11.2.tgz",
+      "integrity": "sha512-CtvoFaBI4hGXlXbaCHf8humajkbXhs39Nbh6MbNxtwJiCqxPy9iH3D3CCfXAvP0QvAAwmJUTK3+z9a++Kc4nkA==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/util": "1.9.3",
+        "node-fetch": "2.6.7",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/storage-compat": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.3.2.tgz",
+      "integrity": "sha512-wvsXlLa9DVOMQJckbDNhXKKxRNNewyUhhbXev3t8kSgoCotd1v3MmqhKKz93ePhDnhHnDs7bYHy+Qa8dRY6BXw==",
+      "dependencies": {
+        "@firebase/component": "0.6.4",
+        "@firebase/storage": "0.11.2",
+        "@firebase/storage-types": "0.8.0",
+        "@firebase/util": "1.9.3",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/storage-types": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.8.0.tgz",
+      "integrity": "sha512-isRHcGrTs9kITJC0AVehHfpraWFui39MPaU7Eo8QfWlqW7YPymBmRgjDrlOgFdURh6Cdeg07zmkLP5tzTKRSpg==",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/util": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.9.3.tgz",
+      "integrity": "sha512-DY02CRhOZwpzO36fHpuVysz6JZrscPiBXD0fXp6qSrL9oNOx5KWICKdR95C0lSITzxp0TZosVyHqzatE8JbcjA==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@firebase/webchannel-wrapper": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.10.3.tgz",
+      "integrity": "sha512-+ZplYUN3HOpgCfgInqgdDAbkGGVzES1cs32JJpeqoh87SkRobGXElJx+1GZSaDqzFL+bYiX18qEcBK76mYs8uA=="
+    },
     "node_modules/@floating-ui/core": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.5.0.tgz",
@@ -2322,6 +2817,35 @@
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.6.tgz",
       "integrity": "sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A=="
+    },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.9.9",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.9.tgz",
+      "integrity": "sha512-vQ1qwi/Kiyprt+uhb1+rHMpyk4CVRMTGNUGGPRGS7pLNfWkdCHrGEnT6T3/JyC2VZgoOX/X1KwdoU0WYQAeYcQ==",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.7.8",
+        "@types/node": ">=12.12.47"
+      },
+      "engines": {
+        "node": "^8.13.0 || >=10.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.7.10",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.10.tgz",
+      "integrity": "sha512-CAqDfoaQ8ykFd9zqBDn4k6iWT9loLAlc2ETmDFS9JCD70gDcnA4L3AFEo2iV7KyAtAAHFW9ftq1Fz+Vsgq80RQ==",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.2.4",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.10",
@@ -3536,6 +4060,60 @@
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
       }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q=="
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ=="
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q=="
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA=="
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw=="
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
     },
     "node_modules/@reduxjs/toolkit": {
       "version": "1.9.6",
@@ -5219,7 +5797,6 @@
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6292,7 +6869,6 @@
     },
     "node_modules/cliui": {
       "version": "8.0.1",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
@@ -8580,7 +9156,6 @@
     },
     "node_modules/faye-websocket": {
       "version": "0.11.4",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "websocket-driver": ">=0.5.1"
@@ -8751,6 +9326,39 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/firebase": {
+      "version": "10.5.2",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-10.5.2.tgz",
+      "integrity": "sha512-LLCig21TBYdByMbGJt5YmUzzk2HpsFCsIUTvOteQjW9BUh40IrSP2+dZi9IvT8RlztM3zcH+TNZ0jOsOaa7GMQ==",
+      "dependencies": {
+        "@firebase/analytics": "0.10.0",
+        "@firebase/analytics-compat": "0.2.6",
+        "@firebase/app": "0.9.22",
+        "@firebase/app-check": "0.8.0",
+        "@firebase/app-check-compat": "0.3.7",
+        "@firebase/app-compat": "0.2.22",
+        "@firebase/app-types": "0.9.0",
+        "@firebase/auth": "1.3.2",
+        "@firebase/auth-compat": "0.4.8",
+        "@firebase/database": "1.0.1",
+        "@firebase/database-compat": "1.0.1",
+        "@firebase/firestore": "4.3.2",
+        "@firebase/firestore-compat": "0.3.21",
+        "@firebase/functions": "0.10.0",
+        "@firebase/functions-compat": "0.3.5",
+        "@firebase/installations": "0.6.4",
+        "@firebase/installations-compat": "0.2.4",
+        "@firebase/messaging": "0.12.4",
+        "@firebase/messaging-compat": "0.2.4",
+        "@firebase/performance": "0.6.4",
+        "@firebase/performance-compat": "0.2.4",
+        "@firebase/remote-config": "0.4.4",
+        "@firebase/remote-config-compat": "0.2.4",
+        "@firebase/storage": "0.11.2",
+        "@firebase/storage-compat": "0.3.2",
+        "@firebase/util": "1.9.3"
+      }
+    },
     "node_modules/flat-cache": {
       "version": "3.0.4",
       "dev": true,
@@ -8908,7 +9516,6 @@
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -9448,7 +10055,6 @@
     },
     "node_modules/http-parser-js": {
       "version": "0.5.8",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/http-proxy": {
@@ -9554,6 +10160,11 @@
       "peerDependencies": {
         "postcss": "^8.1.0"
       }
+    },
+    "node_modules/idb": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
+      "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ=="
     },
     "node_modules/identity-obj-proxy": {
       "version": "3.0.0",
@@ -9931,7 +10542,6 @@
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -12438,6 +13048,11 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
+    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -12650,6 +13265,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/long": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+      "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -12965,6 +13585,44 @@
       "dependencies": {
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/node-forge": {
@@ -14158,6 +14816,29 @@
       "version": "16.13.1",
       "license": "MIT"
     },
+    "node_modules/protobufjs": {
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.5.tgz",
+      "integrity": "sha512-gGXRSXvxQ7UiPgfw8gevrfRWcTlSbOFg+p/N+JVJEK5VhueL2miT6qTymqAmjr1Q5WbOCyJbyrk6JfWKwlFn6A==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "dev": true,
@@ -14622,7 +15303,6 @@
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -15404,7 +16084,6 @@
     },
     "node_modules/string-width": {
       "version": "4.2.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -15417,7 +16096,6 @@
     },
     "node_modules/string-width/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/string.prototype.matchall": {
@@ -15482,7 +16160,6 @@
     },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -16257,7 +16934,6 @@
     },
     "node_modules/tslib": {
       "version": "2.6.2",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/tsutils": {
@@ -17019,7 +17695,6 @@
     },
     "node_modules/websocket-driver": {
       "version": "0.7.4",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "http-parser-js": ">=0.5.1",
@@ -17032,7 +17707,6 @@
     },
     "node_modules/websocket-extensions": {
       "version": "0.1.4",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=0.8.0"
@@ -17173,7 +17847,6 @@
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -17189,7 +17862,6 @@
     },
     "node_modules/wrap-ansi/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -17203,7 +17875,6 @@
     },
     "node_modules/wrap-ansi/node_modules/color-convert": {
       "version": "2.0.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -17214,7 +17885,6 @@
     },
     "node_modules/wrap-ansi/node_modules/color-name": {
       "version": "1.1.4",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/wrappy": {
@@ -17270,7 +17940,6 @@
     },
     "node_modules/y18n": {
       "version": "5.0.8",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -17290,7 +17959,6 @@
     },
     "node_modules/yargs": {
       "version": "17.7.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
@@ -17307,7 +17975,6 @@
     },
     "node_modules/yargs-parser": {
       "version": "21.1.1",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"

--- a/FE/package.json
+++ b/FE/package.json
@@ -29,6 +29,7 @@
     "axios": "^1.5.0",
     "css-loader": "^6.8.1",
     "dayjs": "^1.11.9",
+    "firebase": "^10.5.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-redux": "^8.1.2",

--- a/FE/src/api/firebaseConfig.ts
+++ b/FE/src/api/firebaseConfig.ts
@@ -1,0 +1,22 @@
+// Import the functions you need from the SDKs you need
+import { initializeApp } from "firebase/app";
+import { getAnalytics } from "firebase/analytics";
+// TODO: Add SDKs for Firebase products that you want to use
+// https://firebase.google.com/docs/web/setup#available-libraries
+
+// Your web app's Firebase configuration
+// For Firebase JS SDK v7.20.0 and later, measurementId is optional
+
+const firebaseConfig = {
+  apiKey: process.env.REACT_APP_FIREBASE_API_KEY,
+  authDomain: process.env.REACT_APP_FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.REACT_APP_FIREBASE_PROJECT_ID,
+  storageBucket: process.env.REACT_APP_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: process.env.REACT_APP_FIREBASE_MESSAGING_SENDER_ID,
+  appId: process.env.REACT_APP_FIREBASE_APP_ID,
+  measurementId: process.env.REACT_APP_FIREBASE_MEASUREMENT_ID,
+};
+
+// Initialize Firebase
+export const app = initializeApp(firebaseConfig);
+export const analytics = getAnalytics(app);

--- a/FE/src/api/firebaseConfig.ts
+++ b/FE/src/api/firebaseConfig.ts
@@ -1,6 +1,6 @@
 // Import the functions you need from the SDKs you need
 import { initializeApp } from "firebase/app";
-import { getAnalytics } from "firebase/analytics";
+import { getStorage } from "firebase/storage";
 // TODO: Add SDKs for Firebase products that you want to use
 // https://firebase.google.com/docs/web/setup#available-libraries
 
@@ -18,5 +18,7 @@ const firebaseConfig = {
 };
 
 // Initialize Firebase
-export const app = initializeApp(firebaseConfig);
-export const analytics = getAnalytics(app);
+export const firebaseApp = initializeApp(firebaseConfig);
+
+// Initialize Cloud Storage and get a reference to the service
+export const firebaseStorage = getStorage(firebaseApp);

--- a/FE/src/components/common/Dday/index.tsx
+++ b/FE/src/components/common/Dday/index.tsx
@@ -1,23 +1,27 @@
-import React, { ReactNode, useMemo } from "react";
+import React from "react";
 import Text from "@components/common/Text";
 import colors from "@util/colors";
 import dayjs from "dayjs";
 
 interface Props {
+  nearDate: string | number | Date | dayjs.Dayjs;
   comparedDate: string | number | Date | dayjs.Dayjs;
 }
 
-const Dday = ({ comparedDate }: Props) => {
-  const tempDday = dayjs("2023-11-16"); // (임시)가장 최근 DDAY설정한 날짜
+const Dday = ({ nearDate, comparedDate }: Props) => {
+  const isVisible = nearDate !== null;
 
-  const dday = (function () {
-    let date = dayjs(comparedDate).format("YYYY-MM-DD");
-    let cacl = dayjs(date).diff(dayjs(tempDday), "day");
-    return cacl == 0 ? "-DAY" : cacl < 0 ? cacl : "+" + cacl;
+  const dday = (() => {
+    if (isVisible) {
+      let date = dayjs(comparedDate).format("YYYY-MM-DD");
+      let cacl = dayjs(date).diff(dayjs(nearDate), "day");
+      return cacl == 0 ? "-DAY" : cacl < 0 ? cacl : "+" + cacl;
+    }
   })();
 
-  const style = {
+  const style: React.CSSProperties = {
     color: colors.colorGray_Light_4,
+    visibility: isVisible ? "visible" : "hidden",
   };
 
   return (

--- a/FE/src/components/planner/day/CustomCursor.tsx
+++ b/FE/src/components/planner/day/CustomCursor.tsx
@@ -1,7 +1,7 @@
 import React, { useRef } from "react";
 import styles from "@styles/planner/day.module.scss";
 import { useAppSelector } from "@hooks/hook";
-import { selectTodoItem } from "@store/planner/daySlice";
+import { BASIC_CATEGORY_ITEM, selectTodoItem } from "@store/planner/daySlice";
 
 const throttle = <T extends (...args: any[]) => any>(fn: T, delay: number) => {
   let timeId: ReturnType<typeof setTimeout> | null;
@@ -19,8 +19,9 @@ const throttle = <T extends (...args: any[]) => any>(fn: T, delay: number) => {
 
 const CustomCursor = () => {
   const cursorRef = useRef<SVGSVGElement>(null);
-  const { category } = useAppSelector(selectTodoItem);
-  const [categoryColorCode] = [category!.categoryColorCode];
+  const todoItem = useAppSelector(selectTodoItem);
+  const category = (() => todoItem.category || BASIC_CATEGORY_ITEM)();
+  const categoryColorCode = category.categoryColorCode;
 
   const moveCursor = (e: { clientY: any; clientX: any }) => {
     const mouseY = e.clientY;

--- a/FE/src/components/planner/day/Header.tsx
+++ b/FE/src/components/planner/day/Header.tsx
@@ -7,7 +7,7 @@ import Button from "@components/common/Button";
 import FriendProfile from "@components/common/FriendProfile";
 import { NavigateBefore, NavigateNext } from "@mui/icons-material";
 import { useAppDispatch, useAppSelector } from "@hooks/hook";
-import { setDate, selectDate } from "@store/planner/daySlice";
+import { setDate, selectDate, selectDayInfo } from "@store/planner/daySlice";
 import { todoData_friend } from "@util/data/DayTodos";
 import dayjs from "dayjs";
 import "dayjs/locale/ko";
@@ -67,6 +67,7 @@ const MyHeader = ({ heart }: { heart: number }) => {
 const Header = () => {
   const dispatch = useAppDispatch();
   const date = useAppSelector(selectDate);
+  const { dday: nearDate } = useAppSelector(selectDayInfo);
   const titleDay = dayjs(date).format("YYYY년 M월 DD일 ddd요일");
   const heartNum = 50; // 임시 좋아요 수
   const isFriend = false;
@@ -79,7 +80,7 @@ const Header = () => {
   return (
     <div className={styles["planner-header"]}>
       <div className={styles["planner-header__date"]}>
-        <Dday comparedDate={date} />
+        <Dday nearDate={nearDate} comparedDate={date} />
         <div>
           <Text types="semi-large" bold>
             {titleDay}

--- a/FE/src/components/planner/day/Header.tsx
+++ b/FE/src/components/planner/day/Header.tsx
@@ -73,7 +73,7 @@ const Header = () => {
   const isFriend = false;
 
   const moveDate = (n: -1 | 0 | 1) => {
-    const newDate = n == 0 ? dayjs() : dayjs(date).add(n, "day");
+    const newDate = n == 0 ? dayjs().format("YYYY-MM-DD") : dayjs(date).add(n, "day").format("YYYY-MM-DD");
     dispatch(setDate(newDate));
   };
 

--- a/FE/src/components/planner/day/Header.tsx
+++ b/FE/src/components/planner/day/Header.tsx
@@ -13,10 +13,11 @@ import dayjs from "dayjs";
 import "dayjs/locale/ko";
 dayjs.locale("ko");
 
-const FriendHeader = ({ heart }: { heart: number }) => {
+const FriendHeader = () => {
   const navigate = useNavigate();
-  const [isHeartClick, setIsHeartClick] = useState(false);
-  const [heartNum, setHeartNum] = useState(heart);
+  const { likeCount, like } = useAppSelector(selectDayInfo);
+  const [heartNum, setHeartNum] = useState(likeCount);
+  const [isHeartClick, setIsHeartClick] = useState(like);
 
   function heartClick() {
     setIsHeartClick(!isHeartClick);
@@ -45,8 +46,9 @@ const FriendHeader = ({ heart }: { heart: number }) => {
   );
 };
 
-const MyHeader = ({ heart }: { heart: number }) => {
+const MyHeader = () => {
   const [isSocialClick, setIsSocialClick] = useState(false);
+  const { likeCount } = useAppSelector(selectDayInfo);
 
   function socialClick() {
     setIsSocialClick(!isSocialClick);
@@ -54,7 +56,9 @@ const MyHeader = ({ heart }: { heart: number }) => {
 
   return (
     <div className={styles["planner-header__default"]}>
-      <Button types="red">♥ {heart}</Button>
+      <Button types="red" disabled>
+        ♥ {likeCount}
+      </Button>
       <div className={`${isSocialClick && styles["button__visit"]}`}>
         <Button types="blue" onClick={() => socialClick()}>
           소설공유
@@ -64,13 +68,11 @@ const MyHeader = ({ heart }: { heart: number }) => {
   );
 };
 
-const Header = () => {
+const Header = ({ isFriend }: { isFriend?: boolean }) => {
   const dispatch = useAppDispatch();
   const date = useAppSelector(selectDate);
   const { dday: nearDate } = useAppSelector(selectDayInfo);
   const titleDay = dayjs(date).format("YYYY년 M월 DD일 ddd요일");
-  const heartNum = 50; // 임시 좋아요 수
-  const isFriend = false;
 
   const moveDate = (n: -1 | 0 | 1) => {
     const newDate = n == 0 ? dayjs().format("YYYY-MM-DD") : dayjs(date).add(n, "day").format("YYYY-MM-DD");
@@ -98,7 +100,7 @@ const Header = () => {
           </div>
         </div>
       </div>
-      {isFriend ? <FriendHeader heart={heartNum} /> : <MyHeader heart={heartNum} />}
+      {isFriend ? <FriendHeader /> : <MyHeader />}
     </div>
   );
 };

--- a/FE/src/components/planner/day/Ment.tsx
+++ b/FE/src/components/planner/day/Ment.tsx
@@ -1,22 +1,28 @@
-import React, { useEffect, useState } from "react";
+import React, { Dispatch, SetStateAction, useEffect, useState } from "react";
 import styles from "@styles/planner/day.module.scss";
 import { AddPhotoAlternateOutlined, RemoveCircle } from "@mui/icons-material";
 import { IconButton } from "@mui/material";
 import Text from "@components/common/Text";
 
+interface FileImgeProps {
+  fileImg: string;
+  setFileImg: Dispatch<SetStateAction<string>>;
+}
+
 interface Props {
   title: string;
-  fileImg: boolean;
   maxLength: 50 | 100;
   name: string;
   value: string;
+  isFile?: boolean;
+  fileImg?: string;
+  setFileImg?: Dispatch<SetStateAction<string>>;
   rows?: number;
+  onBlur: React.FocusEventHandler;
   onChange: React.ChangeEventHandler;
 }
 
-const FileImg = () => {
-  const [imgURL, setImgURL] = useState("");
-
+const FileImg = ({ fileImg, setFileImg }: FileImgeProps) => {
   const saveImgFile = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files;
     if (!file) return;
@@ -24,22 +30,22 @@ const FileImg = () => {
     const reader = new FileReader();
     reader.readAsDataURL(file[0]);
     reader.onloadend = () => {
-      setImgURL(reader.result as string);
+      setFileImg(reader.result as string);
       e.target.value = "";
     };
   };
 
   const imgDelete = () => {
-    setImgURL("");
+    setFileImg("");
   };
 
   return (
     <div className={styles["ment-preview__box"]}>
-      <input type="file" id="imageFile" accept="image/*" onChange={(e) => saveImgFile(e)} />
-      {imgURL ? (
+      <input type="file" id="imageFile" accept="image/*" onChange={saveImgFile} />
+      {fileImg ? (
         <div className={styles["ment-preview__img"]}>
-          <img src={imgURL} alt="img-preview" />
-          <IconButton disableRipple onClick={() => imgDelete()}>
+          <img src={fileImg} alt="img-preview" />
+          <IconButton disableRipple onClick={imgDelete}>
             <RemoveCircle fontSize="small" />
           </IconButton>
         </div>
@@ -54,7 +60,7 @@ const FileImg = () => {
   );
 };
 
-const Ment = ({ title, fileImg, rows, ...rest }: Props) => {
+const Ment = ({ title, rows, isFile, fileImg, setFileImg, ...rest }: Props) => {
   const { value, maxLength } = rest;
   const [inputCount, setInputCount] = useState(0);
 
@@ -62,18 +68,25 @@ const Ment = ({ title, fileImg, rows, ...rest }: Props) => {
     setInputCount(value.replace(/<br\s*\/?>/gm, "\n").length);
   }, [value]);
 
+  const handleOnKeyPress = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      if (e.nativeEvent.isComposing) return;
+      (document.activeElement as HTMLElement).blur();
+    }
+  };
+
   return (
     <div className={styles["ment-container"]}>
       <div className={styles["ment-content__box"]}>
-        <Text types="medium" bold>
+        <Text types="semi-medium" bold>
           {title}
         </Text>
-        {rows == 1 ? <input {...rest} /> : <textarea rows={rows} {...rest} />}
+        {rows == 1 ? <input {...rest} onKeyDown={handleOnKeyPress} /> : <textarea rows={rows} {...rest} />}
         <Text types="small">
           ({inputCount}/{maxLength}자)
         </Text>
       </div>
-      {fileImg && <FileImg />}
+      {isFile && <FileImg fileImg={fileImg!} setFileImg={setFileImg!} />}
     </div>
   );
 };
@@ -81,7 +94,7 @@ const Ment = ({ title, fileImg, rows, ...rest }: Props) => {
 Ment.defaultProps = {
   title: "title",
   value: "내용이 들어갑니다.",
-  fileImg: false,
+  fileImg: "",
 };
 
 export default Ment;

--- a/FE/src/components/planner/day/Ment.tsx
+++ b/FE/src/components/planner/day/Ment.tsx
@@ -5,8 +5,8 @@ import { IconButton } from "@mui/material";
 import Text from "@components/common/Text";
 
 interface FileImgeProps {
-  fileImg: string;
-  setFileImg: Dispatch<SetStateAction<string>>;
+  retrospectionImage: File | null;
+  setRetrospectionImage: Dispatch<SetStateAction<File | null>>;
 }
 
 interface Props {
@@ -15,36 +15,49 @@ interface Props {
   name: string;
   value: string;
   isFile?: boolean;
-  fileImg?: string;
-  setFileImg?: Dispatch<SetStateAction<string>>;
+  retrospectionImage?: File | null;
+  setRetrospectionImage?: Dispatch<SetStateAction<File | null>>;
   rows?: number;
   onBlur: React.FocusEventHandler;
   onChange: React.ChangeEventHandler;
 }
 
-const FileImg = ({ fileImg, setFileImg }: FileImgeProps) => {
+const FileImg = ({ retrospectionImage, setRetrospectionImage }: FileImgeProps) => {
+  const [imgPreview, setImgPreview] = useState<string>(() => {
+    const reader = new FileReader();
+    if (retrospectionImage) {
+      reader.readAsDataURL(retrospectionImage);
+      reader.onload = () => {
+        return reader.result;
+      };
+    }
+    return "";
+  });
+
   const saveImgFile = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files;
-    if (!file) return;
+    if (!e.target.files) return;
 
     const reader = new FileReader();
-    reader.readAsDataURL(file[0]);
+    reader.readAsDataURL(e.target.files[0]);
     reader.onloadend = () => {
-      setFileImg(reader.result as string);
+      setImgPreview(reader.result as string);
+      if (e.target.files != null) {
+        setRetrospectionImage(e.target.files[0]);
+      }
       e.target.value = "";
     };
   };
 
   const imgDelete = () => {
-    setFileImg("");
+    setRetrospectionImage(null);
   };
 
   return (
     <div className={styles["ment-preview__box"]}>
       <input type="file" id="imageFile" accept="image/*" onChange={saveImgFile} />
-      {fileImg ? (
+      {imgPreview ? (
         <div className={styles["ment-preview__img"]}>
-          <img src={fileImg} alt="img-preview" />
+          <img src={imgPreview} alt="img-preview" />
           <IconButton disableRipple onClick={imgDelete}>
             <RemoveCircle fontSize="small" />
           </IconButton>
@@ -60,7 +73,7 @@ const FileImg = ({ fileImg, setFileImg }: FileImgeProps) => {
   );
 };
 
-const Ment = ({ title, rows, isFile, fileImg, setFileImg, ...rest }: Props) => {
+const Ment = ({ title, rows, isFile, retrospectionImage, setRetrospectionImage, ...rest }: Props) => {
   const { value, maxLength } = rest;
   const [inputCount, setInputCount] = useState(0);
 
@@ -86,7 +99,7 @@ const Ment = ({ title, rows, isFile, fileImg, setFileImg, ...rest }: Props) => {
           ({inputCount}/{maxLength}자)
         </Text>
       </div>
-      {isFile && <FileImg fileImg={fileImg!} setFileImg={setFileImg!} />}
+      {isFile && <FileImg retrospectionImage={retrospectionImage!} setRetrospectionImage={setRetrospectionImage!} />}
     </div>
   );
 };
@@ -94,7 +107,7 @@ const Ment = ({ title, rows, isFile, fileImg, setFileImg, ...rest }: Props) => {
 Ment.defaultProps = {
   title: "title",
   value: "내용이 들어갑니다.",
-  fileImg: "",
+  retrospectionImage: null,
 };
 
 export default Ment;

--- a/FE/src/components/planner/day/todo/TimeTable.tsx
+++ b/FE/src/components/planner/day/todo/TimeTable.tsx
@@ -168,10 +168,11 @@ const TimeTable = ({ clicked, setClicked }: Props) => {
   }, [selectTime]);
 
   const clickedStyle = clicked ? styles["--clicked"] : "";
+  const todoListNoneStyle = !todoList.length ? styles["--none"] : "";
 
   return (
-    <div className={`${styles["timetable__container"]} ${clickedStyle}`} onClick={() => setClicked(true)}>
-      <div className={styles["timetable__container-box"]}>
+    <div className={styles["timetable__container"]} onClick={() => setClicked(true)}>
+      <div className={`${styles["timetable__container-box"]} ${todoListNoneStyle} ${clickedStyle} `}>
         <div className={styles["timetable__hours"]}>
           {Array.from({ length: 24 }).map((_, idx) => (
             <div key={idx}>{String((4 + idx) % 24).padStart(2, "0")}</div>

--- a/FE/src/components/planner/day/todo/TimeTable.tsx
+++ b/FE/src/components/planner/day/todo/TimeTable.tsx
@@ -103,10 +103,11 @@ const TimeTable = ({ clicked, setClicked }: Props) => {
   useEffect(() => {
     let tempArr = [...makeTimeArr];
     todoList
-      .filter((ele: TodoConfig) => ele.timeTable!.startTime != "" && ele.timeTable!.endTime != "")
+      .filter((ele: TodoConfig) => ele.timeTable && ele.timeTable.startTime != "" && ele.timeTable.endTime != "")
       .map((item: TodoConfig) => {
-        const { todoId, category, timeTable } = item;
-        let { startTime, endTime } = timeTable!;
+        const { todoId, category } = item;
+        const timeTable = item.timeTable!;
+        let { startTime, endTime } = timeTable;
         const miniArr: tableTimeType[] = [];
         let tempTime = startTime;
         while (tempTime != endTime) {

--- a/FE/src/components/planner/day/todo/TimeTable.tsx
+++ b/FE/src/components/planner/day/todo/TimeTable.tsx
@@ -167,10 +167,10 @@ const TimeTable = ({ clicked, setClicked }: Props) => {
     }
   }, [selectTime]);
 
-  const clickedStyle = clicked ? "--clicked" : "";
+  const clickedStyle = clicked ? styles["--clicked"] : "";
 
   return (
-    <div className={styles[`timetable__container${clickedStyle}`]} onClick={() => setClicked(true)}>
+    <div className={`${styles["timetable__container"]} ${clickedStyle}`} onClick={() => setClicked(true)}>
       <div className={styles["timetable__container-box"]}>
         <div className={styles["timetable__hours"]}>
           {Array.from({ length: 24 }).map((_, idx) => (

--- a/FE/src/components/planner/day/todo/TodoItem.tsx
+++ b/FE/src/components/planner/day/todo/TodoItem.tsx
@@ -4,10 +4,9 @@ import Text from "@components/common/Text";
 import Modal from "@components/common/Modal";
 import CategorySelector from "@components/common/CategorySelector";
 import { AddOutlined, DeleteOutlined } from "@mui/icons-material";
-import { BASIC_CATEGORY_ITEM, setTimeTable } from "@store/planner/daySlice";
+import { BASIC_CATEGORY_ITEM } from "@store/planner/daySlice";
 import { TodoConfig } from "@util/planner.interface";
 import { CategoryConfig } from "@util/planner.interface";
-import { useAppDispatch } from "@hooks/hook";
 
 interface Props {
   idx?: number;
@@ -17,14 +16,14 @@ interface Props {
   todoModule: {
     insertTodo: (props: TodoConfig) => void;
     updateTodo: (idx: number, props: TodoConfig) => void;
-    deleteTodo: (idx: number) => void;
+    deleteTodo: (idx: number, todoId: number) => void;
   };
 }
 
 const TodoItem = ({ idx = -1, todoItem, addTodo, disable, todoModule }: Props) => {
-  const dispatch = useAppDispatch();
-  const { todoId, category, todoContent, todoStatus } = todoItem;
-  const [categoryTitle, categoryColorCode] = [category!.categoryTitle, category!.categoryColorCode];
+  const { todoContent, todoStatus } = todoItem;
+  const category = (() => todoItem.category || BASIC_CATEGORY_ITEM)();
+  const [categoryTitle, categoryColorCode] = [category.categoryTitle, category.categoryColorCode];
   const { insertTodo, updateTodo, deleteTodo } = todoModule;
   const [text, setText] = useState(todoContent);
   const dropMenuRef = useRef<HTMLDivElement>(null);
@@ -84,7 +83,7 @@ const TodoItem = ({ idx = -1, todoItem, addTodo, disable, todoModule }: Props) =
   };
 
   const clickDeleteTodo = () => {
-    deleteTodo(idx);
+    deleteTodo(idx, todoItem.todoId);
   };
 
   const getTextColorByBackgroundColor = (hexColor: string) => {

--- a/FE/src/components/planner/day/todo/TodoItem.tsx
+++ b/FE/src/components/planner/day/todo/TodoItem.tsx
@@ -23,7 +23,7 @@ interface Props {
 const TodoItem = ({ idx = -1, todoItem, addTodo, disable, todoModule }: Props) => {
   const { todoContent, todoStatus } = todoItem;
   const category = (() => todoItem.category || BASIC_CATEGORY_ITEM)();
-  const [categoryTitle, categoryColorCode] = [category.categoryTitle, category.categoryColorCode];
+  const { categoryTitle, categoryColorCode } = category;
   const { insertTodo, updateTodo, deleteTodo } = todoModule;
   const [text, setText] = useState(todoContent);
   const dropMenuRef = useRef<HTMLDivElement>(null);

--- a/FE/src/components/planner/day/todo/TodoItem.tsx
+++ b/FE/src/components/planner/day/todo/TodoItem.tsx
@@ -127,7 +127,6 @@ const TodoItem = ({ idx = -1, todoItem, addTodo, disable, todoModule }: Props) =
               placeholder={"할 일을 입력하세요"}
               minLength={2}
               maxLength={maxLength}
-              autoFocus={addTodo}
               onChange={editText}
               onKeyDown={handleOnKeyPress}
               onBlur={handleSaveTextTodo}

--- a/FE/src/components/planner/day/todo/TodoItemChoice.tsx
+++ b/FE/src/components/planner/day/todo/TodoItemChoice.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import styles from "@styles/planner/day.module.scss";
 import Text from "@components/common/Text";
 import { useAppDispatch } from "@hooks/hook";
-import { setTodoItem } from "@store/planner/daySlice";
+import { BASIC_CATEGORY_ITEM, setTodoItem } from "@store/planner/daySlice";
 import { TodoConfig } from "@util/planner.interface";
 
 interface Props {
@@ -13,8 +13,9 @@ interface Props {
 
 const TodoItemChoice = ({ todoItem, possible }: Props) => {
   const dispatch = useAppDispatch();
-  const { category, todoContent, todoStatus } = todoItem;
-  const [categoryTitle, categoryColorCode] = [category!.categoryTitle, category!.categoryColorCode];
+  const { todoContent, todoStatus } = todoItem;
+  const category = (() => todoItem.category || BASIC_CATEGORY_ITEM)();
+  const [categoryTitle, categoryColorCode] = [category.categoryTitle, category.categoryColorCode];
 
   const getTextColorByBackgroundColor = (hexColor: string) => {
     const rgb = parseInt(hexColor, 16);

--- a/FE/src/components/planner/day/todo/TodoItemChoice.tsx
+++ b/FE/src/components/planner/day/todo/TodoItemChoice.tsx
@@ -15,7 +15,7 @@ const TodoItemChoice = ({ todoItem, possible }: Props) => {
   const dispatch = useAppDispatch();
   const { todoContent, todoStatus } = todoItem;
   const category = (() => todoItem.category || BASIC_CATEGORY_ITEM)();
-  const [categoryTitle, categoryColorCode] = [category.categoryTitle, category.categoryColorCode];
+  const { categoryTitle, categoryColorCode } = category;
 
   const getTextColorByBackgroundColor = (hexColor: string) => {
     const rgb = parseInt(hexColor, 16);

--- a/FE/src/components/planner/day/todo/TodoList.tsx
+++ b/FE/src/components/planner/day/todo/TodoList.tsx
@@ -22,7 +22,6 @@ const TodoList = ({ clicked }: Props) => {
     return todoArr.length + 1 >= listSize ? todoArr.length + 1 : listSize;
   }, [todoArr]);
   const todoEndRef = useRef<HTMLDivElement>(null);
-  const nextId = useRef(todoArr.length + 1);
   const copyTodos = useMemo(() => JSON.parse(JSON.stringify(todoArr)), [todoArr]);
 
   useEffect(() => {

--- a/FE/src/components/planner/day/todo/TodoList.tsx
+++ b/FE/src/components/planner/day/todo/TodoList.tsx
@@ -1,10 +1,12 @@
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useEffect, useMemo, useRef } from "react";
 import styles from "@styles/planner/day.module.scss";
 import TodoItem from "@components/planner/day/todo/TodoItem";
 import { useAppDispatch, useAppSelector } from "@hooks/hook";
-import { BASIC_TODO_ITEM, setTodoList, selectTodoList } from "@store/planner/daySlice";
+import { BASIC_TODO_ITEM, setTodoList, selectTodoList, selectDate } from "@store/planner/daySlice";
 import { TodoConfig } from "@util/planner.interface";
 import TodoItemChoice from "./TodoItemChoice";
+import { plannerApi } from "@api/Api";
+import { selectUserId } from "@store/authSlice";
 
 interface Props {
   clicked: boolean;
@@ -12,6 +14,8 @@ interface Props {
 
 const TodoList = ({ clicked }: Props) => {
   const dispatch = useAppDispatch();
+  const userId = useAppSelector(selectUserId);
+  const date = useAppSelector(selectDate);
   const todoArr = useAppSelector(selectTodoList);
   const listSize = 11;
   const todoListSize = useMemo(() => {
@@ -28,20 +32,45 @@ const TodoList = ({ clicked }: Props) => {
   }, [todoArr.length]);
 
   const todoModule = (() => {
-    const insertTodo = (props: TodoConfig) => {
-      copyTodos.push({ ...props, todoId: nextId.current });
-      dispatch(setTodoList(copyTodos));
-      nextId.current += 1;
+    const insertTodo = async (props: TodoConfig) => {
+      await plannerApi
+        .addDailyTodos(userId, {
+          date,
+          todoContent: props.todoContent,
+          categoryId: props.category!.categoryId,
+        })
+        .then((res) => {
+          const todoId = res.data.data["todoId"];
+          copyTodos.push({ ...props, todoId });
+          dispatch(setTodoList(copyTodos));
+        });
     };
 
-    const updateTodo = (idx: number, props: TodoConfig) => {
-      copyTodos[idx] = { ...props };
-      dispatch(setTodoList(copyTodos));
+    const updateTodo = async (idx: number, props: TodoConfig) => {
+      await plannerApi
+        .editDailyTodos(userId, {
+          date,
+          todoId: props.todoId,
+          categoryId: props.category!.categoryId,
+          todoContent: props.todoContent,
+          todoStatus: props.todoStatus,
+        })
+        .then(() => {
+          copyTodos[idx] = { ...props };
+          dispatch(setTodoList(copyTodos));
+        });
     };
 
-    const deleteTodo = (idx: number) => {
-      copyTodos.splice(idx, 1);
-      dispatch(setTodoList(copyTodos));
+    const deleteTodo = async (idx: number, todoId: number) => {
+      await plannerApi
+        .deleteDailyTodos(userId, {
+          date,
+          todoId,
+        })
+        .then(() => {
+          copyTodos.splice(idx, 1);
+          dispatch(setTodoList(copyTodos));
+        });
     };
 
     return {

--- a/FE/src/components/planner/week/list/WeekList.tsx
+++ b/FE/src/components/planner/week/list/WeekList.tsx
@@ -5,14 +5,16 @@ import Dday from "@components/common/Dday";
 import WeekItem from "@components/planner/week/list/WeekItem";
 import WeekItemInput from "@components/planner/week/list/WeekItemInput";
 import { dateFormat } from "@util/getThisWeek";
-import { DayListConfig } from "@store/planner/weekSlice";
+import { DayListConfig, selectWeekDday } from "@store/planner/weekSlice";
 import { TodoConfig } from "@util/planner.interface";
+import { useAppSelector } from "@hooks/hook";
 
 interface Props {
   dayInfo: DayListConfig;
 }
 
 const WeekList = ({ dayInfo }: Props) => {
+  const nearDate = useAppSelector(selectWeekDday);
   const [todoItems, setTodoItems] = useState<TodoConfig[]>(dayInfo.dailyTodo || []);
   const nextId = useRef(todoItems.length + 1);
   const [retrospection, setRetrospection] = useState<string>(dayInfo.retrospection || "");
@@ -21,7 +23,7 @@ const WeekList = ({ dayInfo }: Props) => {
     <div className={styles["item"]}>
       <div className={styles["item__title"]}>
         <Text>{dateFormat(dayInfo.date)}</Text>
-        <Dday comparedDate={dateFormat(dayInfo.date)} />
+        <Dday nearDate={nearDate} comparedDate={dateFormat(dayInfo.date)} />
       </div>
       <div className={styles["item__todo-list"]} style={{ gridTemplateRows: `repeat(${todoItems.length + 1}, 20%` }}>
         {todoItems.map((item, key) => (

--- a/FE/src/pages/Planner/DayPage.tsx
+++ b/FE/src/pages/Planner/DayPage.tsx
@@ -15,7 +15,7 @@ import { selectUserId } from "@store/authSlice";
 const DayPage = () => {
   const dispatch = useAppDispatch();
   const userId = useAppSelector(selectUserId);
-  const friendUserId = userId;
+  const friendUserId = 3;
   const date = useAppSelector(selectDate);
   const todoList = useAppSelector(selectTodoList);
   const [ment, setMent] = useState({

--- a/FE/src/pages/Planner/DayPage.tsx
+++ b/FE/src/pages/Planner/DayPage.tsx
@@ -36,7 +36,6 @@ const DayPage = () => {
       .daily(userId, { date: day })
       .then((res) => {
         const response = res.data.data;
-        console.log("플래너 조회", response);
         dispatch(
           setDayInfo({
             plannerAccessScope: response.plannerAccessScope,

--- a/FE/src/pages/Planner/DayPage.tsx
+++ b/FE/src/pages/Planner/DayPage.tsx
@@ -23,7 +23,6 @@ const DayPage = () => {
     tomorrowGoal: "",
     retrospection: "",
   });
-  const [retrospectionImage, setRetrospectionImage] = useState<File | null>(null);
   const [isClickTimeTable, setIsClickTimeTable] = useState(false);
   const todoDivRef = useRef<HTMLDivElement>(null);
   const [totalTime, setTotalTime] = useState({
@@ -37,12 +36,14 @@ const DayPage = () => {
       .daily(friedUserId, { date: day })
       .then((res) => {
         const response = res.data.data;
+        console.log(response);
         dispatch(
           setDayInfo({
             plannerAccessScope: response.plannerAccessScope,
             dday: response.dday,
             like: response.like,
             likeCount: response.likeCount,
+            retrospectionImage: response.retrospectionImage,
             dailyTodos: response.dailyTodos || [],
           }),
         );
@@ -51,7 +52,6 @@ const DayPage = () => {
           todayGoal: response.todayGoal || "",
           tomorrowGoal: response.tomorrowGoal || "",
         });
-        setRetrospectionImage(response.retrospectionImage);
         setTotalTime({ studyTimeHour: response.studyTimeHour, studyTimeMinute: response.studyTimeMinute });
       })
       .catch((err) => console.error(err));
@@ -69,15 +69,6 @@ const DayPage = () => {
     const studyTimeMinute = Math.floor(sumMinute % 60);
     setTotalTime({ studyTimeHour, studyTimeMinute });
   }, [todoList]);
-
-  useEffect(() => {
-    // 파이어베이스 연결 후 조건문 지울 예정
-    if (retrospectionImage)
-      plannerApi
-        .retrospectionImages(userId, { date, retrospectionImage: null })
-        .then((res) => console.log("이미지 업로드", res))
-        .catch((err) => console.error(err));
-  }, [retrospectionImage]);
 
   (() => {
     const handleOutsideClose = (e: MouseEvent) => {
@@ -163,8 +154,6 @@ const DayPage = () => {
           rows={5}
           maxLength={100}
           isFile
-          retrospectionImage={retrospectionImage}
-          setRetrospectionImage={setRetrospectionImage}
           onBlur={saveRetrospections}
         />
 

--- a/FE/src/pages/Planner/DayPage.tsx
+++ b/FE/src/pages/Planner/DayPage.tsx
@@ -15,7 +15,7 @@ import { selectUserId } from "@store/authSlice";
 const DayPage = () => {
   const dispatch = useAppDispatch();
   const userId = useAppSelector(selectUserId);
-  const friendUserId = 3;
+  const friendUserId = userId;
   const date = useAppSelector(selectDate);
   const todoList = useAppSelector(selectTodoList);
   const [ment, setMent] = useState({
@@ -70,23 +70,22 @@ const DayPage = () => {
     setTotalTime({ studyTimeHour, studyTimeMinute });
   }, [todoList]);
 
-  (() => {
+  useEffect(() => {
     const handleOutsideClose = (e: MouseEvent) => {
-      if (todoDivRef && todoDivRef.current) {
-        if (e.button == 2) handleClickTimeTable(false);
+      if (todoDivRef && todoDivRef.current && e.button == 2) {
+        setIsClickTimeTable(false);
       }
     };
     document.addEventListener("mouseup", handleOutsideClose);
     document.addEventListener("contextmenu", (e) => e.preventDefault());
     return () => document.addEventListener("mouseup", handleOutsideClose);
-  })();
+  }, []);
 
   useEffect(() => {
     const handleOutsideClose = (e: { target: any }) => {
-      if (isClickTimeTable && !todoDivRef.current?.contains(e.target)) handleClickTimeTable(false);
+      if (isClickTimeTable && !todoDivRef.current?.contains(e.target)) setIsClickTimeTable(false);
     };
     document.addEventListener("click", handleOutsideClose);
-
     return () => document.removeEventListener("click", handleOutsideClose);
   }, [isClickTimeTable]);
 
@@ -112,7 +111,7 @@ const DayPage = () => {
   };
 
   const handleClickTimeTable = (props: boolean) => {
-    if (userId == friendUserId) setIsClickTimeTable(props);
+    if (userId == friendUserId && todoList.length > 0) setIsClickTimeTable(props);
   };
 
   const { saveTodayGoals, saveRetrospections, saveTomorrowGoals } = handleSaveMent;

--- a/FE/src/pages/Planner/DayPage.tsx
+++ b/FE/src/pages/Planner/DayPage.tsx
@@ -1,51 +1,72 @@
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import Header from "@components/planner/day/Header";
 import styles from "@styles/planner/day.module.scss";
 import TimeTable from "@components/planner/day/todo/TimeTable";
 import TodoList from "@components/planner/day/todo/TodoList";
 import Ment from "@components/planner/day/Ment";
-import { useAppSelector } from "@hooks/hook";
-import { selectTodoList } from "@store/planner/daySlice";
+import { useAppDispatch, useAppSelector } from "@hooks/hook";
+import { selectDate, selectTodoList, setDayInfo } from "@store/planner/daySlice";
 import CustomCursor from "@components/planner/day/CustomCursor";
 import dayjs from "dayjs";
 import { TodoConfig } from "@util/planner.interface";
+import { plannerApi } from "@api/Api";
+import { selectUserId } from "@store/authSlice";
 
 const DayPage = () => {
+  const dispatch = useAppDispatch();
+  const userId = useAppSelector(selectUserId);
+  const date = useAppSelector(selectDate);
+  const todoList = useAppSelector(selectTodoList);
   const [ment, setMent] = useState({
     todayGoals: "",
     tomorrowGoals: "",
     retrospections: "",
   });
-  const todoListData = useAppSelector(selectTodoList);
-  const totalTime = useMemo(() => {
-    const sumMinute = todoListData
+  const [isClickTimeTable, setIsClickTimeTable] = useState(false);
+  const todoDivRef = useRef<HTMLDivElement>(null);
+  const [totalTime, setTotalTime] = useState({
+    studyTimeHour: 0,
+    studyTimeMinute: 0,
+  });
+
+  useEffect(() => {
+    const day = dayjs(date).format("YYYY-MM-DD");
+    plannerApi
+      .daily(userId, { date: day })
+      .then((res) => {
+        const response = res.data.data;
+        dispatch(
+          setDayInfo({
+            plannerAccessScope: response.plannerAccessScope,
+            dday: response.dday || "",
+            like: response.like,
+            likeCount: response.likeCount,
+            retrospection: response.retrospection || "",
+            retrospectionImage: response.retrospectionImage || "",
+            todayGoal: response.todayGoal || "",
+            tomorrowGoal: response.tomorrowGoal || "",
+            dailyTodos: response.dailyTodos || [],
+          }),
+        );
+        setTotalTime({ studyTimeHour: response.studyTimeHour, studyTimeMinute: response.studyTimeMinute });
+      })
+      .catch((err) => console.error(err));
+  }, [date]);
+
+  useEffect(() => {
+    const sumMinute = todoList
       .filter((ele: TodoConfig) => ele.timeTable!.startTime != "" && ele.timeTable!.endTime != "")
       .reduce(
         (accumulator: number, item: { timeTable: any }) =>
           accumulator + Number(dayjs(item.timeTable!.endTime).diff(dayjs(item.timeTable!.startTime), "m")),
         0,
       );
+    const studyTimeHour = Math.floor(sumMinute / 60);
+    const studyTimeMinute = Math.floor(sumMinute % 60);
+    setTotalTime({ studyTimeHour, studyTimeMinute });
+  }, [todoList]);
 
-    return {
-      studyTimeHour: Math.floor(sumMinute / 60),
-      studyTimeMinute: Math.floor(sumMinute % 60),
-    };
-  }, [todoListData]);
-  const [isClickTimeTable, setIsClickTimeTable] = useState(false);
-  const todoDivRef = useRef<HTMLDivElement>(null);
-
-  const handleInput = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    setMent({
-      ...ment,
-      [e.target.name]: e.target.value,
-    });
-  };
-
-  const handleClickTimeTable = (props: boolean) => {
-    setIsClickTimeTable(props);
-  };
-
-  useEffect(() => {
+  (() => {
     const handleOutsideClose = (e: MouseEvent) => {
       if (todoDivRef && todoDivRef.current) {
         if (e.button == 2) handleClickTimeTable(false);
@@ -54,7 +75,11 @@ const DayPage = () => {
     document.addEventListener("mouseup", handleOutsideClose);
     document.addEventListener("contextmenu", (e) => e.preventDefault());
     return () => document.addEventListener("mouseup", handleOutsideClose);
-  }, []);
+  })();
+
+  const handleClickTimeTable = (props: boolean) => {
+    setIsClickTimeTable(props);
+  };
 
   useEffect(() => {
     const handleOutsideClose = (e: { target: any }) => {
@@ -64,11 +89,18 @@ const DayPage = () => {
     return () => document.removeEventListener("click", handleOutsideClose);
   }, [isClickTimeTable]);
 
+  const handleInput = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setMent({
+      ...ment,
+      [e.target.name]: e.target.value,
+    });
+  };
+
   const { todayGoals, tomorrowGoals, retrospections } = ment;
   const { studyTimeHour, studyTimeMinute } = totalTime;
 
   return (
-    <div className={styles["page-container"]}>
+    <div className={styles["page-container"]} key={date}>
       <Header />
       <div className={styles["page-content"]}>
         <Ment

--- a/FE/src/pages/Planner/DayPage.tsx
+++ b/FE/src/pages/Planner/DayPage.tsx
@@ -15,7 +15,7 @@ import { selectUserId } from "@store/authSlice";
 const DayPage = () => {
   const dispatch = useAppDispatch();
   const userId = useAppSelector(selectUserId);
-  const friedUserId = userId;
+  const friendUserId = userId;
   const date = useAppSelector(selectDate);
   const todoList = useAppSelector(selectTodoList);
   const [ment, setMent] = useState({
@@ -34,7 +34,7 @@ const DayPage = () => {
   useEffect(() => {
     const day = dayjs(date).format("YYYY-MM-DD");
     plannerApi
-      .daily(friedUserId, { date: day })
+      .daily(friendUserId, { date: day })
       .then((res) => {
         const response = res.data.data;
         dispatch(
@@ -73,7 +73,7 @@ const DayPage = () => {
   (() => {
     const handleOutsideClose = (e: MouseEvent) => {
       if (todoDivRef && todoDivRef.current) {
-        if (e.button == 2) setIsClickTimeTable(false);
+        if (e.button == 2) handleClickTimeTable(false);
       }
     };
     document.addEventListener("mouseup", handleOutsideClose);
@@ -83,7 +83,7 @@ const DayPage = () => {
 
   useEffect(() => {
     const handleOutsideClose = (e: { target: any }) => {
-      if (isClickTimeTable && !todoDivRef.current?.contains(e.target)) setIsClickTimeTable(false);
+      if (isClickTimeTable && !todoDivRef.current?.contains(e.target)) handleClickTimeTable(false);
     };
     document.addEventListener("click", handleOutsideClose);
 
@@ -111,14 +111,19 @@ const DayPage = () => {
     });
   };
 
+  const handleClickTimeTable = (props: boolean) => {
+    if (userId == friendUserId) setIsClickTimeTable(props);
+  };
+
   const { saveTodayGoals, saveRetrospections, saveTomorrowGoals } = handleSaveMent;
   const { todayGoal, tomorrowGoal, retrospection } = ment;
   const { studyTimeHour, studyTimeMinute } = totalTime;
+  const isFriend = userId != friendUserId;
 
   return (
     <div className={styles["page-container"]} key={date}>
-      <Header isFriend={userId != friedUserId} />
-      <div className={styles["page-content"]} style={{ pointerEvents: userId != friedUserId ? "none" : "auto" }}>
+      <Header isFriend={userId != friendUserId} />
+      <div className={`${styles["page-content"]} ${isFriend ? styles["--friend"] : ""}`}>
         <Ment
           title={"오늘의 다짐"}
           name="todayGoal"
@@ -142,7 +147,7 @@ const DayPage = () => {
             <TodoList clicked={isClickTimeTable} />
           </div>
           <div className={styles["item__timetable"]}>
-            <TimeTable clicked={isClickTimeTable} setClicked={() => setIsClickTimeTable(true)} />
+            <TimeTable clicked={isClickTimeTable} setClicked={handleClickTimeTable} />
           </div>
         </div>
 

--- a/FE/src/pages/Planner/DayPage.tsx
+++ b/FE/src/pages/Planner/DayPage.tsx
@@ -36,6 +36,7 @@ const DayPage = () => {
       .daily(userId, { date: day })
       .then((res) => {
         const response = res.data.data;
+        console.log("플래너 조회", response);
         dispatch(
           setDayInfo({
             plannerAccessScope: response.plannerAccessScope,
@@ -58,7 +59,7 @@ const DayPage = () => {
 
   useEffect(() => {
     const sumMinute = todoList
-      .filter((ele: TodoConfig) => ele.timeTable!.startTime != "" && ele.timeTable!.endTime != "")
+      .filter((ele: TodoConfig) => ele.timeTable && ele.timeTable.startTime != "" && ele.timeTable.endTime != "")
       .reduce(
         (accumulator: number, item: { timeTable: any }) =>
           accumulator + Number(dayjs(item.timeTable!.endTime).diff(dayjs(item.timeTable!.startTime), "m")),

--- a/FE/src/pages/Planner/DayPage.tsx
+++ b/FE/src/pages/Planner/DayPage.tsx
@@ -23,6 +23,7 @@ const DayPage = () => {
     tomorrowGoal: "",
     retrospection: "",
   });
+  const [retrospectionImage, setRetrospectionImage] = useState<string | null>(null);
   const [isClickTimeTable, setIsClickTimeTable] = useState(false);
   const todoDivRef = useRef<HTMLDivElement>(null);
   const [totalTime, setTotalTime] = useState({
@@ -36,14 +37,12 @@ const DayPage = () => {
       .daily(friedUserId, { date: day })
       .then((res) => {
         const response = res.data.data;
-        console.log(response);
         dispatch(
           setDayInfo({
             plannerAccessScope: response.plannerAccessScope,
             dday: response.dday,
             like: response.like,
             likeCount: response.likeCount,
-            retrospectionImage: response.retrospectionImage,
             dailyTodos: response.dailyTodos || [],
           }),
         );
@@ -52,6 +51,7 @@ const DayPage = () => {
           todayGoal: response.todayGoal || "",
           tomorrowGoal: response.tomorrowGoal || "",
         });
+        setRetrospectionImage(response.retrospectionImage);
         setTotalTime({ studyTimeHour: response.studyTimeHour, studyTimeMinute: response.studyTimeMinute });
       })
       .catch((err) => console.error(err));
@@ -154,6 +154,8 @@ const DayPage = () => {
           rows={5}
           maxLength={100}
           isFile
+          retrospectionImage={retrospectionImage}
+          setRetrospectionImage={setRetrospectionImage}
           onBlur={saveRetrospections}
         />
 

--- a/FE/src/pages/Planner/DayPage.tsx
+++ b/FE/src/pages/Planner/DayPage.tsx
@@ -38,7 +38,7 @@ const DayPage = () => {
         dispatch(
           setDayInfo({
             plannerAccessScope: response.plannerAccessScope,
-            dday: response.dday || "",
+            dday: response.dday,
             like: response.like,
             likeCount: response.likeCount,
             retrospection: response.retrospection || "",

--- a/FE/src/pages/Planner/DayPage.tsx
+++ b/FE/src/pages/Planner/DayPage.tsx
@@ -22,7 +22,7 @@ const DayPage = () => {
     tomorrowGoal: "",
     retrospection: "",
   });
-  const [retrospectionImage, setRetrospectionImage] = useState("");
+  const [retrospectionImage, setRetrospectionImage] = useState<File | null>(null);
   const [isClickTimeTable, setIsClickTimeTable] = useState(false);
   const todoDivRef = useRef<HTMLDivElement>(null);
   const [totalTime, setTotalTime] = useState({
@@ -50,7 +50,7 @@ const DayPage = () => {
           todayGoal: response.todayGoal || "",
           tomorrowGoal: response.tomorrowGoal || "",
         });
-        setRetrospectionImage(response.retrospectionImage || "");
+        setRetrospectionImage(response.retrospectionImage);
         setTotalTime({ studyTimeHour: response.studyTimeHour, studyTimeMinute: response.studyTimeMinute });
       })
       .catch((err) => console.error(err));
@@ -68,6 +68,15 @@ const DayPage = () => {
     const studyTimeMinute = Math.floor(sumMinute % 60);
     setTotalTime({ studyTimeHour, studyTimeMinute });
   }, [todoList]);
+
+  useEffect(() => {
+    // 파이어베이스 연결 후 조건문 지울 예정
+    if (retrospectionImage)
+      plannerApi
+        .retrospectionImages(userId, { date, retrospectionImage: null })
+        .then((res) => console.log("이미지 업로드", res))
+        .catch((err) => console.error(err));
+  }, [retrospectionImage]);
 
   (() => {
     const handleOutsideClose = (e: MouseEvent) => {
@@ -153,8 +162,8 @@ const DayPage = () => {
           rows={5}
           maxLength={100}
           isFile
-          fileImg={retrospectionImage}
-          setFileImg={setRetrospectionImage}
+          retrospectionImage={retrospectionImage}
+          setRetrospectionImage={setRetrospectionImage}
           onBlur={saveRetrospections}
         />
 

--- a/FE/src/pages/Planner/DayPage.tsx
+++ b/FE/src/pages/Planner/DayPage.tsx
@@ -15,6 +15,7 @@ import { selectUserId } from "@store/authSlice";
 const DayPage = () => {
   const dispatch = useAppDispatch();
   const userId = useAppSelector(selectUserId);
+  const friedUserId = userId;
   const date = useAppSelector(selectDate);
   const todoList = useAppSelector(selectTodoList);
   const [ment, setMent] = useState({
@@ -33,7 +34,7 @@ const DayPage = () => {
   useEffect(() => {
     const day = dayjs(date).format("YYYY-MM-DD");
     plannerApi
-      .daily(userId, { date: day })
+      .daily(friedUserId, { date: day })
       .then((res) => {
         const response = res.data.data;
         dispatch(
@@ -125,8 +126,8 @@ const DayPage = () => {
 
   return (
     <div className={styles["page-container"]} key={date}>
-      <Header />
-      <div className={styles["page-content"]}>
+      <Header isFriend={userId != friedUserId} />
+      <div className={styles["page-content"]} style={{ pointerEvents: userId != friedUserId ? "none" : "auto" }}>
         <Ment
           title={"오늘의 다짐"}
           name="todayGoal"

--- a/FE/src/pages/commonPage.tsx
+++ b/FE/src/pages/commonPage.tsx
@@ -35,7 +35,7 @@ const commonPage = () => {
         <Button children="로그아웃" types="gray" />
       </div>
       <div>
-        <Dday comparedDate={new Date()} />
+        <Dday nearDate={new Date()} comparedDate={new Date()} />
       </div>
       <br />
       <div style={{ width: "25em", display: "flex", flexDirection: "column" }}>

--- a/FE/src/store/planner/daySlice.ts
+++ b/FE/src/store/planner/daySlice.ts
@@ -12,7 +12,6 @@ interface dayInfoConfig {
   dday: string | null;
   like: boolean;
   likeCount: number;
-  retrospectionImage: string | null;
   dailyTodos: TodoConfig[];
 }
 
@@ -29,7 +28,6 @@ const initialState: dayConfig = {
     dday: null,
     like: false,
     likeCount: 0,
-    retrospectionImage: null,
     dailyTodos: [],
   },
   todoItem: {
@@ -56,9 +54,6 @@ const daySlice = createSlice({
   reducers: {
     setDayInfo: (state, action: PayloadAction<dayConfig["info"]>) => {
       state.info = action.payload;
-    },
-    setDayRetrospectionImage: (state, action: PayloadAction<dayInfoConfig["retrospectionImage"]>) => {
-      state.info.retrospectionImage = action.payload;
     },
     setDate: (state, action: PayloadAction<dayConfig["date"]>) => {
       state.date = action.payload;
@@ -102,8 +97,7 @@ const daySlice = createSlice({
 
 export const BASIC_TODO_ITEM = initialState.todoItem!;
 export const BASIC_CATEGORY_ITEM = initialState.todoItem.category!;
-export const { setDayInfo, setDayRetrospectionImage, setDate, setTodoItem, removeTodoItem, setTodoList, setTimeTable } =
-  daySlice.actions;
+export const { setDayInfo, setDate, setTodoItem, removeTodoItem, setTodoList, setTimeTable } = daySlice.actions;
 export const selectDate = (state: rootState) => state.day.date;
 export const selectDayInfo = (state: rootState) => state.day.info;
 export const selectTodoItem = (state: rootState) => state.day.todoItem;

--- a/FE/src/store/planner/daySlice.ts
+++ b/FE/src/store/planner/daySlice.ts
@@ -12,6 +12,7 @@ interface dayInfoConfig {
   dday: string | null;
   like: boolean;
   likeCount: number;
+  retrospectionImage: string | null;
   dailyTodos: TodoConfig[];
 }
 
@@ -28,6 +29,7 @@ const initialState: dayConfig = {
     dday: null,
     like: false,
     likeCount: 0,
+    retrospectionImage: null,
     dailyTodos: [],
   },
   todoItem: {
@@ -54,6 +56,9 @@ const daySlice = createSlice({
   reducers: {
     setDayInfo: (state, action: PayloadAction<dayConfig["info"]>) => {
       state.info = action.payload;
+    },
+    setDayRetrospectionImage: (state, action: PayloadAction<dayInfoConfig["retrospectionImage"]>) => {
+      state.info.retrospectionImage = action.payload;
     },
     setDate: (state, action: PayloadAction<dayConfig["date"]>) => {
       state.date = action.payload;
@@ -97,7 +102,8 @@ const daySlice = createSlice({
 
 export const BASIC_TODO_ITEM = initialState.todoItem!;
 export const BASIC_CATEGORY_ITEM = initialState.todoItem.category!;
-export const { setDayInfo, setDate, setTodoItem, removeTodoItem, setTodoList, setTimeTable } = daySlice.actions;
+export const { setDayInfo, setDayRetrospectionImage, setDate, setTodoItem, removeTodoItem, setTodoList, setTimeTable } =
+  daySlice.actions;
 export const selectDate = (state: rootState) => state.day.date;
 export const selectDayInfo = (state: rootState) => state.day.info;
 export const selectTodoItem = (state: rootState) => state.day.todoItem;

--- a/FE/src/store/planner/daySlice.ts
+++ b/FE/src/store/planner/daySlice.ts
@@ -1,7 +1,6 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { rootState } from "@hooks/configStore";
 import { TodoConfig, TimeTableConfig } from "@util/planner.interface";
-import { todoData_list } from "@util/data/DayTodos";
 import dayjs from "dayjs";
 import isSameOrBefore from "dayjs/plugin/isSameOrBefore";
 import isSameOrAfter from "dayjs/plugin/isSameOrAfter";
@@ -11,30 +10,22 @@ dayjs.extend(isSameOrAfter);
 interface dayInfoConfig {
   plannerAccessScope: "전체공개" | "친구공개" | "비공개";
   dday: string | null;
-  todayGoal: string;
-  retrospection: string;
-  retrospectionImage: string;
-  tomorrowGoal: string;
   like: boolean;
   likeCount: number;
   dailyTodos: TodoConfig[];
 }
 
 interface dayConfig {
-  date: string | Date | dayjs.Dayjs;
+  date: string;
   info: dayInfoConfig;
   todoItem: TodoConfig; // 내가 선택한 todo
 }
 
 const initialState: dayConfig = {
-  date: new Date(),
+  date: dayjs().format("YYYY-MM-DD"),
   info: {
     plannerAccessScope: "전체공개",
     dday: null,
-    todayGoal: "",
-    retrospection: "",
-    retrospectionImage: "",
-    tomorrowGoal: "",
     like: false,
     likeCount: 0,
     dailyTodos: [],

--- a/FE/src/store/planner/daySlice.ts
+++ b/FE/src/store/planner/daySlice.ts
@@ -8,14 +8,37 @@ import isSameOrAfter from "dayjs/plugin/isSameOrAfter";
 dayjs.extend(isSameOrBefore);
 dayjs.extend(isSameOrAfter);
 
+interface dayInfoConfig {
+  plannerAccessScope: "전체공개" | "친구공개" | "비공개";
+  dday: string | Date | dayjs.Dayjs;
+  todayGoal: string;
+  retrospection: string;
+  retrospectionImage: string;
+  tomorrowGoal: string;
+  like: boolean;
+  likeCount: number;
+  dailyTodos: TodoConfig[];
+}
+
 interface dayConfig {
   date: string | Date | dayjs.Dayjs;
-  todoItem: TodoConfig;
-  dailyTodo: TodoConfig[];
+  info: dayInfoConfig;
+  todoItem: TodoConfig; // 내가 선택한 todo
 }
 
 const initialState: dayConfig = {
   date: new Date(),
+  info: {
+    plannerAccessScope: "전체공개",
+    dday: "",
+    todayGoal: "",
+    retrospection: "",
+    retrospectionImage: "",
+    tomorrowGoal: "",
+    like: false,
+    likeCount: 0,
+    dailyTodos: [],
+  },
   todoItem: {
     todoId: 0,
     todoContent: "",
@@ -32,13 +55,15 @@ const initialState: dayConfig = {
       endTime: "",
     },
   },
-  dailyTodo: todoData_list,
 };
 
 const daySlice = createSlice({
   name: "plannerDay",
   initialState,
   reducers: {
+    setDayInfo: (state, action: PayloadAction<dayConfig["info"]>) => {
+      state.info = action.payload;
+    },
     setDate: (state, action: PayloadAction<dayConfig["date"]>) => {
       state.date = action.payload;
     },
@@ -48,13 +73,13 @@ const daySlice = createSlice({
     removeTodoItem: (state) => {
       state.todoItem = initialState.todoItem;
     },
-    setTodoList: (state, action: PayloadAction<dayConfig["dailyTodo"]>) => {
-      state.dailyTodo = action.payload;
+    setTodoList: (state, action: PayloadAction<dayInfoConfig["dailyTodos"]>) => {
+      state.info.dailyTodos = action.payload;
     },
     setTimeTable: (state, action: PayloadAction<{ todoId: number; startTime: string; endTime: string }>) => {
       const { todoId, startTime, endTime } = action.payload;
 
-      const tempArr = state.dailyTodo.map((item) => {
+      const tempArr = state.info.dailyTodos.map((item) => {
         if (startTime != "" && item.timeTable && item.timeTable.startTime != "") {
           if (
             !(
@@ -74,16 +99,16 @@ const daySlice = createSlice({
         tempArr[findIndex].timeTable = { ...timeTableInfo, startTime, endTime };
       }
 
-      state.dailyTodo = tempArr;
+      state.info.dailyTodos = tempArr;
     },
   },
 });
 
 export const BASIC_TODO_ITEM = initialState.todoItem!;
 export const BASIC_CATEGORY_ITEM = initialState.todoItem.category!;
-export const { setDate, setTodoItem, removeTodoItem, setTodoList, setTimeTable } = daySlice.actions;
+export const { setDayInfo, setDate, setTodoItem, removeTodoItem, setTodoList, setTimeTable } = daySlice.actions;
 export const selectDate = (state: rootState) => state.day.date;
 export const selectTodoItem = (state: rootState) => state.day.todoItem;
-export const selectTodoList = (state: rootState) => state.day.dailyTodo;
+export const selectTodoList = (state: rootState) => state.day.info.dailyTodos;
 
 export default daySlice.reducer;

--- a/FE/src/store/planner/daySlice.ts
+++ b/FE/src/store/planner/daySlice.ts
@@ -10,7 +10,7 @@ dayjs.extend(isSameOrAfter);
 
 interface dayInfoConfig {
   plannerAccessScope: "전체공개" | "친구공개" | "비공개";
-  dday: string | Date | dayjs.Dayjs;
+  dday: string | null;
   todayGoal: string;
   retrospection: string;
   retrospectionImage: string;
@@ -30,7 +30,7 @@ const initialState: dayConfig = {
   date: new Date(),
   info: {
     plannerAccessScope: "전체공개",
-    dday: "",
+    dday: null,
     todayGoal: "",
     retrospection: "",
     retrospectionImage: "",
@@ -108,6 +108,7 @@ export const BASIC_TODO_ITEM = initialState.todoItem!;
 export const BASIC_CATEGORY_ITEM = initialState.todoItem.category!;
 export const { setDayInfo, setDate, setTodoItem, removeTodoItem, setTodoList, setTimeTable } = daySlice.actions;
 export const selectDate = (state: rootState) => state.day.date;
+export const selectDayInfo = (state: rootState) => state.day.info;
 export const selectTodoItem = (state: rootState) => state.day.todoItem;
 export const selectTodoList = (state: rootState) => state.day.info.dailyTodos;
 

--- a/FE/src/store/planner/weekSlice.ts
+++ b/FE/src/store/planner/weekSlice.ts
@@ -47,5 +47,6 @@ export const { setWeekInfo, setWeeklyTodos, setThisWeek } = weekSlice.actions;
 export const selectDayList = (state: rootState) => state.week.dayList;
 export const selectWeeklyTodos = (state: rootState) => state.week.weeklyTodos;
 export const selectThisWeek = (state: rootState) => state.week.thisWeek;
+export const selectWeekDday = (state: rootState) => state.week.dday;
 
 export default weekSlice.reducer;

--- a/FE/src/styles/planner/day.module.scss
+++ b/FE/src/styles/planner/day.module.scss
@@ -86,7 +86,10 @@ $color-btn-blue: var(--color-btn-blue);
     .todo-item,
     .timetable__container-box {
       pointer-events: auto;
-      > * {
+      &::after {
+        content: "";
+      }
+      & > * {
         pointer-events: none;
       }
     }
@@ -406,26 +409,6 @@ $color-btn-blue: var(--color-btn-blue);
     padding: 0em 0.2em;
     box-sizing: border-box;
 
-    &::after {
-      @extend .text-small;
-      position: absolute;
-      top: 50%;
-      left: 50%;
-      transform: translate(-50%, -50%);
-      opacity: 0.5;
-      margin: 0 0 1.2em 1.2em;
-      text-align: center;
-      white-space: pre;
-      line-height: 1.5em;
-      content: "클릭하여\A타임 테이블 등록";
-    }
-
-    &.--clicked {
-      &::after {
-        content: "";
-      }
-    }
-
     &-box {
       height: 100%;
       overflow-y: auto;
@@ -433,6 +416,24 @@ $color-btn-blue: var(--color-btn-blue);
       display: grid;
       grid-template-columns: 1fr 8fr;
       grid-template-rows: 1fr;
+
+      &::after {
+        @extend .text-small;
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        opacity: 0.5;
+        margin: 0 0 1.2em 1.2em;
+        text-align: center;
+        white-space: pre;
+        line-height: 1.5em;
+        content: "클릭하여\A타임 테이블 등록";
+      }
+
+      &.--clicked::after {
+        content: "";
+      }
     }
   }
 

--- a/FE/src/styles/planner/day.module.scss
+++ b/FE/src/styles/planner/day.module.scss
@@ -79,6 +79,18 @@ $color-btn-blue: var(--color-btn-blue);
       z-index: 2;
     }
   }
+
+  &.--friend {
+    pointer-events: none;
+
+    .todo-item,
+    .timetable__container-box {
+      pointer-events: auto;
+      > * {
+        pointer-events: none;
+      }
+    }
+  }
 }
 
 .planner-header {
@@ -393,6 +405,7 @@ $color-btn-blue: var(--color-btn-blue);
     overflow-y: auto;
     padding: 0em 0.2em;
     box-sizing: border-box;
+
     &::after {
       @extend .text-small;
       position: absolute;
@@ -407,8 +420,7 @@ $color-btn-blue: var(--color-btn-blue);
       content: "클릭하여\A타임 테이블 등록";
     }
 
-    &--clicked {
-      @extend .timetable__container;
+    &.--clicked {
       &::after {
         content: "";
       }

--- a/FE/src/styles/planner/day.module.scss
+++ b/FE/src/styles/planner/day.module.scss
@@ -431,6 +431,10 @@ $color-btn-blue: var(--color-btn-blue);
         content: "클릭하여\A타임 테이블 등록";
       }
 
+      &.--none::after {
+        content: "할 일이 완료되면\A공부 시간을 기록할 수 있습니다.";
+      }
+
       &.--clicked::after {
         content: "";
       }

--- a/FE/src/styles/planner/day.module.scss
+++ b/FE/src/styles/planner/day.module.scss
@@ -6,6 +6,7 @@ $color-gray_1: var(--color-gray-1);
 $color-text: var(--color-text);
 $color-warning: var(--color-warning);
 $color-background: var(--color-background);
+$color-btn-red: var(--color-btn-red);
 $color-btn-blue: var(--color-btn-blue);
 
 %item-container {
@@ -110,36 +111,35 @@ $color-btn-blue: var(--color-btn-blue);
     }
   }
 
+  button {
+    width: 6rem;
+  }
+
+  .button__visit > button {
+    box-shadow: inset 0px 3px 6px 0px rgba(black, 0.4);
+  }
+
   &__default {
     display: flex;
     justify-content: flex-end;
     padding-right: 0.2em;
     gap: 10px;
 
-    > div {
-      width: 5.5em;
+    > button {
       &:nth-child(1) {
-        cursor: default;
-        &:hover {
-          background-color: var(--color-btn-red);
-        }
+        background-color: $color-btn-red;
         &:active {
           box-shadow: none;
         }
       }
     }
-
-    > .button__visit > div {
-      box-shadow: inset 0px 3px 6px 0px rgba(0, 0, 0, 0.25);
-    }
   }
 
   &__friend {
     height: 100%;
-    display: flex;
+    display: grid;
     justify-items: end;
-    justify-content: flex-end;
-    align-items: flex-end;
+    grid-template-columns: 1fr 1fr;
     gap: 0.5em;
 
     > div:nth-child(1) {
@@ -148,14 +148,13 @@ $color-btn-blue: var(--color-btn-blue);
       flex-direction: column;
       justify-content: space-evenly;
 
-      > div {
-        width: 5.5em;
+      .button__visit > button > span {
+        color: #f00;
       }
     }
 
     > div:nth-child(2) {
       width: 100%;
-      max-width: 28em;
     }
   }
 }

--- a/FE/src/util/data/DayTodos.ts
+++ b/FE/src/util/data/DayTodos.ts
@@ -10,19 +10,19 @@ export const todoData_friend = {
 
 export const todoData_category: CategoryConfig[] = [
   {
-    categoryId: 1,
+    categoryId: 44,
     categoryTitle: "국어",
     categoryColorCode: "#FFCBE1",
     categoryEmoticon: "📓",
   },
   {
-    categoryId: 2,
+    categoryId: 45,
     categoryTitle: "수학",
     categoryColorCode: "#B6F7E1",
     categoryEmoticon: "📐",
   },
   {
-    categoryId: 3,
+    categoryId: 46,
     categoryTitle: "과학 뿌셔뿌셔 대항전",
     categoryColorCode: "#B6DEF7",
     categoryEmoticon: "🧪",


### PR DESCRIPTION
close #

## 어떤 이유로 MR를 하셨나요?

- [ ] test 코드 작성
- [x] feature 병합
- [ ] 버그 수정
- [ ] 코드 개선
- [ ] 기타(아래에 자세한 내용 기입해주세요)

## 세부 내용 - 왜 해당 MR이 필요한지 자세하게 설명해주세요

- 일별 플래너 조회 API 연결, 해당 데이터로 렌더링
- 일별 플래너 todo 작성, 수정, 삭제 API 연결
- 타임테이블 표시, 삭제 API 연결
- 오늘의 다짐, 회고, 내일의 다짐 API 연결
- 오늘의 회고 사진 업로드 API 연결
- 파이어베이스 설정 및 회고 사진 업로드
- Dday 공통 컴포넌트에 조회 플래너 일자와 가장 근접한 dday 날짜 props 추가
  - 근접한 dday가 없을 경우(null인 경우) 플래너 dday 표시 안하게 함
- 친구의 일별 플래너 조회일 경우, 헤더 아래 이벤트 동작 막기

(  ⚠해당 브랜치는 카테고리가 연동이 안 되어있어서 할 일 작성이나 수정할 때, 버그가 생길 수 있음!  
  테스트하려면 카테고리는 배포된 서버에서 따로 만들고, 더미데이터에서 categoryId만 수정해서 사용해야함)

(일별 플래너에서 좋아요 API와 소셜 공유하는 API는 친구와 소셜 API 적용 이후 적용할 계획)


## MR하기 전에 확인해주세요

- [x] 커밋 컨벤션을 맞췄나요?
- [x] 오류나는 코드는 없나요?
