### PR TITLE
[FE] 마이페이지 친구 API 연결

### DIFF
--- a/FE/src/api/Api.ts
+++ b/FE/src/api/Api.ts
@@ -30,7 +30,7 @@ export const followApi = {
   deleteFollowing: (userId: number, data: { followingId: number }) =>
     Axios.delete(api.follow.following(userId), { data: data }),
   getFollwers: (userId: number) => Axios.get(api.follow.followers(userId)),
-  deletefollowers: (userId: number, data: { followerId: number }) =>
+  deleteFollowers: (userId: number, data: { followerId: number }) =>
     Axios.delete(api.follow.followers(userId), { data: data }),
   addRequested: (userId: number, data: { followingId: number }) => Axios.post(api.follow.requested(userId), data),
   cancelRequested: (userId: number, data: { receiverId: number }) =>

--- a/FE/src/api/Api.ts
+++ b/FE/src/api/Api.ts
@@ -30,12 +30,12 @@ export const followApi = {
   deleteFollowing: (userId: number, data: { followingId: number }) =>
     Axios.delete(api.follow.following(userId), { data: data }),
   getFollwers: (userId: number) => Axios.get(api.follow.followers(userId)),
-  deleteFollows: (userId: number, data: { followerId: number }) =>
+  deletefollowers: (userId: number, data: { followerId: number }) =>
     Axios.delete(api.follow.followers(userId), { data: data }),
   addRequested: (userId: number, data: { followingId: number }) => Axios.post(api.follow.requested(userId), data),
   cancelRequested: (userId: number, data: { receiverId: number }) =>
     Axios.delete(api.follow.requested(userId), { data: data }),
-  receive: (userId: number, data: { requestId: number; followReceive: boolean }) =>
+  receive: (userId: number, data: { requesterId: number; followReceive: boolean }) =>
     Axios.post(api.follow.receive(userId), data),
   receiveList: (userId: number) => Axios.get(api.follow.receiveList(userId)),
 };

--- a/FE/src/api/Api.ts
+++ b/FE/src/api/Api.ts
@@ -30,12 +30,12 @@ export const followApi = {
   deleteFollowing: (userId: number, data: { followingId: number }) =>
     Axios.delete(api.follow.following(userId), { data: data }),
   getFollwers: (userId: number) => Axios.get(api.follow.followers(userId)),
-  deleteFollows: (userId: number, data: { followingId: number }) =>
+  deleteFollows: (userId: number, data: { followerId: number }) =>
     Axios.delete(api.follow.followers(userId), { data: data }),
   addRequested: (userId: number, data: { followingId: number }) => Axios.post(api.follow.requested(userId), data),
-  canelRequested: (userId: number, data: { followingId: number }) =>
+  cancelRequested: (userId: number, data: { receiverId: number }) =>
     Axios.delete(api.follow.requested(userId), { data: data }),
-  receive: (userId: number, data: { requesertId: number; followReceive: boolean }) =>
+  receive: (userId: number, data: { requestId: number; followReceive: boolean }) =>
     Axios.post(api.follow.receive(userId), data),
   receiveList: (userId: number) => Axios.get(api.follow.receiveList(userId)),
 };

--- a/FE/src/api/Api.ts
+++ b/FE/src/api/Api.ts
@@ -22,6 +22,7 @@ export const userApi = {
   editProfileImg: (userId: number, data: { newProfileImage: string }) =>
     Axios.put(api.users.editProfileImg(userId), data),
   deleteProfileImg: (userId: number) => Axios.delete(api.users.editProfileImg(userId)),
+  searches: (userId: number, params: { nickname: string }) => Axios.get(api.users.searches(userId), { params }),
 };
 
 export const followApi = {
@@ -31,8 +32,6 @@ export const followApi = {
   getFollwers: (userId: number) => Axios.get(api.follow.followers(userId)),
   deleteFollows: (userId: number, data: { followingId: number }) =>
     Axios.delete(api.follow.followers(userId), { data: data }),
-  searches: (userId: number, params: { nickname: string }) =>
-    Axios.post(api.follow.searches(userId), {}, { params: params }),
   addRequested: (userId: number, data: { followingId: number }) => Axios.post(api.follow.requested(userId), data),
   canelRequested: (userId: number, data: { followingId: number }) =>
     Axios.delete(api.follow.requested(userId), { data: data }),

--- a/FE/src/api/BaseUrl.ts
+++ b/FE/src/api/BaseUrl.ts
@@ -24,11 +24,11 @@ interface apiInterface {
     password: (userId: number) => string; // 비밀번호 수정
     userOut: (userId: number) => string; // 회원 탈퇴
     editProfileImg: (userId: number) => string; // 프로필 사진 등록, 수정
+    searches: (userId: number) => string; // 회원 검색
   };
   follow: {
     following: (userId: number) => string; // 팔로잉 조회, 삭제
     followers: (userId: number) => string; // 팔로워 조회, 삭제
-    searches: (userId: number) => string; // 회원 검색
     requested: (userId: number) => string; // 팔로우 신청, 취소
     receive: (userId: number) => string; // 팔로우 신청 수락, 거절
     receiveList: (userId: number) => string; // 받은 팔로우 신청 목록(친구신청 목록)
@@ -76,11 +76,11 @@ const api: apiInterface = {
     password: (userId: number) => HOST + USERS + userId + "/password",
     userOut: (userId: number) => HOST + USERS + userId,
     editProfileImg: (userId: number) => HOST + USERS + userId + "/images",
+    searches: (userId: number) => HOST + USERS + userId + "/searches",
   },
   follow: {
     following: (userId: number) => HOST + FOLLOW + userId + "/following",
     followers: (userId: number) => HOST + FOLLOW + userId + "/followers",
-    searches: (userId: number) => HOST + FOLLOW + userId + "/searches",
     requested: (userId: number) => HOST + FOLLOW + userId + "/requested",
     receive: (userId: number) => HOST + FOLLOW + userId + "/receive",
     receiveList: (userId: number) => HOST + FOLLOW + userId + "/receive-lists",

--- a/FE/src/components/common/FriendProfile/index.tsx
+++ b/FE/src/components/common/FriendProfile/index.tsx
@@ -40,19 +40,33 @@ const ProfileButton = ({ profileId, types }: ProfileButtonProps) => {
         // .then((res) => console.log("팔로우취소", res))
         .catch((err) => console.error(err));
     };
+    const deleteFollower = () => {
+      followApi
+        .deletefollowers(userId, { followerId: profileId })
+        // .then((res) => console.log("팔로워 삭제", res))
+        .catch((err) => console.error(err));
+    };
+    const deleteFollowing = () => {
+      followApi
+        .deleteFollowing(userId, { followingId: profileId })
+        // .then((res) => console.log("팔로잉 삭제", res))
+        .catch((err) => console.error(err));
+    };
 
     return {
       followRequested,
       cancelRequested,
+      deleteFollower,
+      deleteFollowing,
     };
   })();
 
-  const { followRequested, cancelRequested } = handleClick;
+  const { followRequested, cancelRequested, deleteFollower, deleteFollowing } = handleClick;
 
   return {
     기본: <></>,
-    "팔로워 삭제": <button>삭제</button>,
-    "팔로잉 삭제": <button>삭제</button>,
+    "팔로워 삭제": <button onClick={deleteFollower}>삭제</button>,
+    "팔로잉 삭제": <button onClick={deleteFollowing}>삭제</button>,
     "친구 신청": (
       <button style={{ backgroundColor: "var(--color-btn-blue)" }} onClick={followRequested}>
         친구 신청

--- a/FE/src/components/common/FriendProfile/index.tsx
+++ b/FE/src/components/common/FriendProfile/index.tsx
@@ -4,9 +4,10 @@ import Text from "@components/common/Text";
 import PersonAddIcon from "@mui/icons-material/PersonAdd";
 import { Avatar } from "@mui/material";
 import { followApi } from "@api/Api";
-import { useAppSelector } from "@hooks/hook";
+import { useAppDispatch, useAppSelector } from "@hooks/hook";
 import { selectUserId } from "@store/authSlice";
 import { followType } from "@util/friend.interface";
+import { setFollowState } from "@store/friendSlice";
 
 export interface ProfileConfig {
   userId: number;
@@ -25,26 +26,50 @@ interface ProfileButtonProps extends Omit<Props, "profile"> {
 }
 
 const ProfileButton = ({ profileId, types }: ProfileButtonProps) => {
+  const dispatch = useAppDispatch();
   const userId = useAppSelector(selectUserId);
+  const [state, setState] = useState(0);
+
+  useEffect(() => {
+    if (state != 0) dispatch(setFollowState({ followState: state }));
+  }, [state]);
 
   const handleClick = (() => {
-    const followRequested = () => {
-      followApi.addRequested(userId, { followingId: profileId }).catch((err) => console.error(err));
+    const followRequested = async () => {
+      await followApi
+        .addRequested(userId, { followingId: profileId })
+        .then(() => setState(1))
+        .catch((err) => console.error(err));
     };
-    const cancelRequested = () => {
-      followApi.cancelRequested(userId, { receiverId: profileId }).catch((err) => console.error(err));
+    const cancelRequested = async () => {
+      await followApi
+        .cancelRequested(userId, { receiverId: profileId })
+        .then(() => setState(2))
+        .catch((err) => console.error(err));
     };
-    const receiveAcceptiance = () => {
-      followApi.receive(userId, { requesterId: profileId, followReceive: true }).catch((err) => console.error(err));
+    const receiveAcceptiance = async () => {
+      await followApi
+        .receive(userId, { requesterId: profileId, followReceive: true })
+        .then(() => setState(3))
+        .catch((err) => console.error(err));
     };
-    const receiveRefusal = () => {
-      followApi.receive(userId, { requesterId: profileId, followReceive: false }).catch((err) => console.error(err));
+    const receiveRefusal = async () => {
+      await followApi
+        .receive(userId, { requesterId: profileId, followReceive: false })
+        .then(() => setState(4))
+        .catch((err) => console.error(err));
     };
-    const deleteFollower = () => {
-      followApi.deletefollowers(userId, { followerId: profileId }).catch((err) => console.error(err));
+    const deleteFollower = async () => {
+      await followApi
+        .deletefollowers(userId, { followerId: profileId })
+        .then(() => setState(5))
+        .catch((err) => console.error(err));
     };
-    const deleteFollowing = () => {
-      followApi.deleteFollowing(userId, { followingId: profileId }).catch((err) => console.error(err));
+    const deleteFollowing = async () => {
+      await followApi
+        .deleteFollowing(userId, { followingId: profileId })
+        .then(() => setState(6))
+        .catch((err) => console.error(err));
     };
 
     return {

--- a/FE/src/components/common/FriendProfile/index.tsx
+++ b/FE/src/components/common/FriendProfile/index.tsx
@@ -29,39 +29,36 @@ const ProfileButton = ({ profileId, types }: ProfileButtonProps) => {
 
   const handleClick = (() => {
     const followRequested = () => {
-      followApi
-        .addRequested(userId, { followingId: profileId })
-        // .then(() => setRender("요청"))
-        .catch((err) => console.error(err));
+      followApi.addRequested(userId, { followingId: profileId }).catch((err) => console.error(err));
     };
     const cancelRequested = () => {
-      followApi
-        .cancelRequested(userId, { receiverId: profileId })
-        // .then((res) => console.log("팔로우취소", res))
-        .catch((err) => console.error(err));
+      followApi.cancelRequested(userId, { receiverId: profileId }).catch((err) => console.error(err));
+    };
+    const receiveAcceptiance = () => {
+      followApi.receive(userId, { requesterId: profileId, followReceive: true }).catch((err) => console.error(err));
+    };
+    const receiveRefusal = () => {
+      followApi.receive(userId, { requesterId: profileId, followReceive: false }).catch((err) => console.error(err));
     };
     const deleteFollower = () => {
-      followApi
-        .deletefollowers(userId, { followerId: profileId })
-        // .then((res) => console.log("팔로워 삭제", res))
-        .catch((err) => console.error(err));
+      followApi.deletefollowers(userId, { followerId: profileId }).catch((err) => console.error(err));
     };
     const deleteFollowing = () => {
-      followApi
-        .deleteFollowing(userId, { followingId: profileId })
-        // .then((res) => console.log("팔로잉 삭제", res))
-        .catch((err) => console.error(err));
+      followApi.deleteFollowing(userId, { followingId: profileId }).catch((err) => console.error(err));
     };
 
     return {
       followRequested,
       cancelRequested,
+      receiveAcceptiance,
+      receiveRefusal,
       deleteFollower,
       deleteFollowing,
     };
   })();
 
-  const { followRequested, cancelRequested, deleteFollower, deleteFollowing } = handleClick;
+  const { followRequested, cancelRequested, receiveAcceptiance, receiveRefusal, deleteFollower, deleteFollowing } =
+    handleClick;
 
   return {
     기본: <></>,
@@ -82,8 +79,10 @@ const ProfileButton = ({ profileId, types }: ProfileButtonProps) => {
     ),
     요청: (
       <>
-        <button style={{ backgroundColor: "var(--color-btn-blue)" }}>수락</button>
-        <button>거절</button>
+        <button style={{ backgroundColor: "var(--color-btn-blue)" }} onClick={receiveAcceptiance}>
+          수락
+        </button>
+        <button onClick={receiveRefusal}>거절</button>
       </>
     ),
     취소: (

--- a/FE/src/components/common/FriendProfile/index.tsx
+++ b/FE/src/components/common/FriendProfile/index.tsx
@@ -1,25 +1,26 @@
-import React, { DOMAttributes, MouseEventHandler } from "react";
+import React from "react";
 import styles from "@styles/common/Profile.module.scss";
 import Text from "@components/common/Text";
 import PersonAddIcon from "@mui/icons-material/PersonAdd";
 import { Avatar } from "@mui/material";
 
 export interface ProfileConfig {
+  userId: number;
   nickname: string;
   message: string;
   src: string;
 }
 
 interface Props {
+  profile: ProfileConfig;
   types: "기본" | "삭제" | "친구 신청" | "팔로워 신청" | "요청" | "취소" | "아이콘";
 }
 
-interface ProfileProps extends Props {
-  profile: ProfileConfig;
-  onClick?: MouseEventHandler<HTMLDivElement>;
+interface ProfileButtonProps extends Omit<Props, "profile"> {
+  profileId: number;
 }
 
-const ProfileButton = ({ types }: Props) => {
+const ProfileButton = ({ profileId, types }: ProfileButtonProps) => {
   return {
     기본: <></>,
     삭제: <button>삭제</button>,
@@ -49,7 +50,7 @@ const ProfileButton = ({ types }: Props) => {
   }[types];
 };
 
-const FriendProfile = ({ types, profile, ...rest }: ProfileProps) => {
+const FriendProfile = ({ types, profile }: Props) => {
   return (
     <div className={styles["fprofile_container"]}>
       <div className={styles["profile_img"]}>
@@ -61,9 +62,7 @@ const FriendProfile = ({ types, profile, ...rest }: ProfileProps) => {
         </Text>
         <Text types="default">{profile?.message}</Text>
       </div>
-      <div className={styles["fprofile_button"]} {...rest}>
-        {<ProfileButton types={types} />}
-      </div>
+      <div className={styles["fprofile_button"]}>{<ProfileButton profileId={profile.userId} types={types} />}</div>
     </div>
   );
 };

--- a/FE/src/components/common/FriendProfile/index.tsx
+++ b/FE/src/components/common/FriendProfile/index.tsx
@@ -1,8 +1,11 @@
-import React from "react";
+import React, { useState } from "react";
 import styles from "@styles/common/Profile.module.scss";
 import Text from "@components/common/Text";
 import PersonAddIcon from "@mui/icons-material/PersonAdd";
 import { Avatar } from "@mui/material";
+import { followApi } from "@api/Api";
+import { useAppSelector } from "@hooks/hook";
+import { selectUserId } from "@store/authSlice";
 
 export interface ProfileConfig {
   userId: number;
@@ -21,13 +24,37 @@ interface ProfileButtonProps extends Omit<Props, "profile"> {
 }
 
 const ProfileButton = ({ profileId, types }: ProfileButtonProps) => {
+  const userId = useAppSelector(selectUserId);
+  const [render, setRender] = useState(types);
+
+  const handleClick = (() => {
+    const followRequested = () => {
+      followApi
+        .addRequested(userId, { followingId: profileId })
+        .then(() => setRender("요청"))
+        .catch((err) => console.error(err));
+    };
+
+    return {
+      followRequested,
+    };
+  })();
+
+  const { followRequested } = handleClick;
+
   return {
     기본: <></>,
     삭제: <button>삭제</button>,
-    "친구 신청": <button style={{ backgroundColor: "var(--color-btn-blue)" }}>친구 신청</button>,
+    "친구 신청": (
+      <button style={{ backgroundColor: "var(--color-btn-blue)" }} onClick={followRequested}>
+        친구 신청
+      </button>
+    ),
     "팔로워 신청": (
       <>
-        <button style={{ backgroundColor: "var(--color-btn-blue)" }}>친구 신청</button>
+        <button style={{ backgroundColor: "var(--color-btn-blue)" }} onClick={followRequested}>
+          친구 신청
+        </button>
         <button>거절</button>
       </>
     ),
@@ -43,7 +70,7 @@ const ProfileButton = ({ profileId, types }: ProfileButtonProps) => {
       </button>
     ),
     아이콘: (
-      <div>
+      <div onClick={followRequested}>
         <PersonAddIcon />
       </div>
     ),

--- a/FE/src/components/common/FriendProfile/index.tsx
+++ b/FE/src/components/common/FriendProfile/index.tsx
@@ -61,7 +61,7 @@ const ProfileButton = ({ profileId, types }: ProfileButtonProps) => {
     };
     const deleteFollower = async () => {
       await followApi
-        .deletefollowers(userId, { followerId: profileId })
+        .deleteFollowers(userId, { followerId: profileId })
         .then(() => setState(5))
         .catch((err) => console.error(err));
     };

--- a/FE/src/components/common/FriendProfile/index.tsx
+++ b/FE/src/components/common/FriendProfile/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import styles from "@styles/common/Profile.module.scss";
 import Text from "@components/common/Text";
 import PersonAddIcon from "@mui/icons-material/PersonAdd";
@@ -6,6 +6,7 @@ import { Avatar } from "@mui/material";
 import { followApi } from "@api/Api";
 import { useAppSelector } from "@hooks/hook";
 import { selectUserId } from "@store/authSlice";
+import { followType } from "@util/friend.interface";
 
 export interface ProfileConfig {
   userId: number;
@@ -16,7 +17,7 @@ export interface ProfileConfig {
 
 interface Props {
   profile: ProfileConfig;
-  types: "기본" | "삭제" | "친구 신청" | "팔로워 신청" | "요청" | "취소" | "아이콘";
+  types: "기본" | "아이콘" | followType["types"];
 }
 
 interface ProfileButtonProps extends Omit<Props, "profile"> {
@@ -25,26 +26,33 @@ interface ProfileButtonProps extends Omit<Props, "profile"> {
 
 const ProfileButton = ({ profileId, types }: ProfileButtonProps) => {
   const userId = useAppSelector(selectUserId);
-  const [render, setRender] = useState(types);
 
   const handleClick = (() => {
     const followRequested = () => {
       followApi
         .addRequested(userId, { followingId: profileId })
-        .then(() => setRender("요청"))
+        // .then(() => setRender("요청"))
+        .catch((err) => console.error(err));
+    };
+    const cancelRequested = () => {
+      followApi
+        .cancelRequested(userId, { receiverId: profileId })
+        // .then((res) => console.log("팔로우취소", res))
         .catch((err) => console.error(err));
     };
 
     return {
       followRequested,
+      cancelRequested,
     };
   })();
 
-  const { followRequested } = handleClick;
+  const { followRequested, cancelRequested } = handleClick;
 
   return {
     기본: <></>,
-    삭제: <button>삭제</button>,
+    "팔로워 삭제": <button>삭제</button>,
+    "팔로잉 삭제": <button>삭제</button>,
     "친구 신청": (
       <button style={{ backgroundColor: "var(--color-btn-blue)" }} onClick={followRequested}>
         친구 신청
@@ -55,7 +63,7 @@ const ProfileButton = ({ profileId, types }: ProfileButtonProps) => {
         <button style={{ backgroundColor: "var(--color-btn-blue)" }} onClick={followRequested}>
           친구 신청
         </button>
-        <button>거절</button>
+        <button>삭제</button>
       </>
     ),
     요청: (
@@ -65,7 +73,7 @@ const ProfileButton = ({ profileId, types }: ProfileButtonProps) => {
       </>
     ),
     취소: (
-      <button style={{ backgroundColor: "var(--color-gray-2)" }}>
+      <button style={{ backgroundColor: "var(--color-gray-2)" }} onClick={cancelRequested}>
         <span style={{ color: "var(--color-text)" }}>요청 취소</span>
       </button>
     ),

--- a/FE/src/components/mypage/details/friend/MyFriend.tsx
+++ b/FE/src/components/mypage/details/friend/MyFriend.tsx
@@ -1,8 +1,9 @@
 import React, { useEffect, useState } from "react";
 import styles from "@styles/mypage/MyPage.module.scss";
 import { followerType, followingType, followRequestType } from "@util/friend.interface";
-import { selectUserId } from "@store/authSlice";
 import { useAppSelector } from "@hooks/hook";
+import { selectUserId } from "@store/authSlice";
+import { selectFollowState } from "@store/friendSlice";
 import { followApi } from "@api/Api";
 import MyFriendFrame from "./MyFriendFrame";
 
@@ -11,6 +12,7 @@ const MyFriend = ({ title }: { title: "팔로워" | "팔로잉" | "친구검색"
   const [followRequestData, setFollowRequestData] = useState<followRequestType[]>([]); // 팔로우 요청
   const [followerData, setFolloweData] = useState<followerType[]>([]); // 내 팔로워
   const [followingData, setFollowingData] = useState<followingType[]>([]); // 내 팔로잉
+  const followState: boolean = useAppSelector(selectFollowState);
 
   useEffect(() => {
     switch (title) {
@@ -40,7 +42,7 @@ const MyFriend = ({ title }: { title: "팔로워" | "팔로잉" | "친구검색"
           .catch((err) => console.error(err));
         break;
     }
-  }, [title]);
+  }, [title, followState]);
 
   return (
     <div className={styles["friend__cantainer"]}>

--- a/FE/src/components/mypage/details/friend/MyFriend.tsx
+++ b/FE/src/components/mypage/details/friend/MyFriend.tsx
@@ -1,79 +1,47 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import styles from "@styles/mypage/MyPage.module.scss";
-import Text from "@components/common/Text";
-import Input from "@components/common/Input";
-import FriendProfile from "@components/common/FriendProfile";
-import { followerListData, followingListData, followRequestData, FriendSearch } from "@util/data/FriendData";
 import { followerType, followingType, followRequestType } from "@util/friend.interface";
-
-interface MyFriendListType {
-  followId?: number;
-  followerId?: number;
-  followRequestId?: number;
-  receiveId?: number;
-  userId?: number;
-  email: string;
-  nickname: string;
-  profileImage: string;
-  statusMessage: string;
-  isFollow?: "삭제" | "친구 신청" | "팔로워 신청" | "요청" | "취소";
-}
-
-interface Props {
-  title: string;
-  search?: boolean;
-  friendList?: (followerType | followingType | followRequestType)[];
-}
-
-const MyFriendFrame = ({ title, search, friendList }: Props) => {
-  const [searchKeyWord, setSearchKeyWord] = useState("");
-
-  const onChangeHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setSearchKeyWord(e.target.value);
-  };
-
-  const friendCheck = (friend: MyFriendListType) => {
-    if (friend.followId) {
-      if (friend.isFollow) return { id: friend.followId, isFollow: friend.isFollow };
-      else return { id: friend.followId, isFollow: "삭제" };
-    } else if (friend.followRequestId) return { id: friend.followRequestId, isFollow: "요청" };
-    else return { id: friend.userId, isFollow: friend.isFollow };
-  };
-
-  return (
-    <div className={styles["friend__frame"]}>
-      <div className={styles["friend__frame__title"]}>
-        <Text bold>{title}</Text>
-      </div>
-      {search && (
-        <Input types="search" value={searchKeyWord} onChange={onChangeHandler} placeholder="사용자 닉네임으로 검색" />
-      )}
-      <div className={styles["friend__frame__list"]}>
-        {friendList && friendList.length > 0 ? (
-          friendList.map((item, index) => {
-            const { id, isFollow } = friendCheck(item);
-            const followInfo = {
-              nickname: item.nickname,
-              message: item.statusMessage,
-              src: item.profileImage,
-            };
-            return (
-              <FriendProfile
-                key={id}
-                types={isFollow as "삭제" | "친구 신청" | "팔로워 신청" | "요청" | "취소"}
-                profile={followInfo}
-              />
-            );
-          })
-        ) : (
-          <Text types="small">{title}이(가) 없습니다.</Text>
-        )}
-      </div>
-    </div>
-  );
-};
+import { selectUserId } from "@store/authSlice";
+import { useAppSelector } from "@hooks/hook";
+import { followApi } from "@api/Api";
+import MyFriendFrame from "./MyFriendFrame";
 
 const MyFriend = ({ title }: { title: "팔로워" | "팔로잉" | "친구검색" }) => {
+  const userId: number = useAppSelector(selectUserId);
+  const [followRequestData, setFollowRequestData] = useState<followRequestType[]>([]); // 팔로우 요청
+  const [followerData, setFolloweData] = useState<followerType[]>([]); // 내 팔로워
+  const [followingData, setFollowingData] = useState<followingType[]>([]); // 내 팔로잉
+
+  useEffect(() => {
+    switch (title) {
+      case "팔로워":
+        followApi
+          .receiveList(userId)
+          .then((res) => {
+            const response = res.data.data;
+            setFollowRequestData(response);
+          })
+          .catch((err) => console.error(err));
+        followApi
+          .getFollwers(userId)
+          .then((res) => {
+            const response = res.data.data;
+            setFolloweData(response);
+          })
+          .catch((err) => console.error(err));
+        break;
+      case "팔로잉":
+        followApi
+          .getFollowing(userId)
+          .then((res) => {
+            const response = res.data.data;
+            setFollowingData(response);
+          })
+          .catch((err) => console.error(err));
+        break;
+    }
+  }, [title]);
+
   return (
     <div className={styles["friend__cantainer"]}>
       <div className={styles["friend__content"]}>
@@ -84,10 +52,10 @@ const MyFriend = ({ title }: { title: "팔로워" | "팔로잉" | "친구검색"
                 {followRequestData.length != 0 && (
                   <MyFriendFrame title="팔로우 요청 목록" friendList={followRequestData} />
                 )}
-                <MyFriendFrame title="내 팔로워" friendList={followerListData} />
+                <MyFriendFrame title="내 팔로워" friendList={followerData} />
               </>
             ),
-            팔로잉: <MyFriendFrame title="내 팔로잉" friendList={followingListData} />,
+            팔로잉: <MyFriendFrame title="내 팔로잉" friendList={followingData} />,
             친구검색: <MyFriendFrame title="친구 검색" search />,
           }[title]
         }

--- a/FE/src/components/mypage/details/friend/MyFriendFrame.tsx
+++ b/FE/src/components/mypage/details/friend/MyFriendFrame.tsx
@@ -3,18 +3,18 @@ import styles from "@styles/mypage/MyPage.module.scss";
 import Text from "@components/common/Text";
 import Input from "@components/common/Input";
 import FriendProfile from "@components/common/FriendProfile";
-import { followerType, followingType, followRequestType } from "@util/friend.interface";
+import { followerType, followingType, followRequestType, friendInfo, friendSearchType } from "@util/friend.interface";
+import { selectUserId } from "@store/authSlice";
+import { useAppSelector } from "@hooks/hook";
+import { userApi } from "@api/Api";
+import { useDebounce } from "@util/EventControlModule";
 
-interface MyFriendListType {
+interface MyFriendListType extends friendInfo {
   followId?: number;
   followerId?: number;
   followRequestId?: number;
   receiveId?: number;
   userId?: number;
-  email: string;
-  nickname: string;
-  profileImage: string;
-  statusMessage: string;
   isFollow?: "삭제" | "친구 신청" | "팔로워 신청" | "요청" | "취소";
 }
 
@@ -25,11 +25,32 @@ interface Props {
 }
 
 const MyFriendFrame = ({ title, search, friendList }: Props) => {
+  const userId: number = useAppSelector(selectUserId);
+  const [searchFriend, setSearchFriend] = useState<friendSearchType[]>([]);
   const [searchKeyWord, setSearchKeyWord] = useState("");
+  const debounceKeyword = useDebounce(searchKeyWord, 500);
 
   const onChangeHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
     setSearchKeyWord(e.target.value);
   };
+
+  useEffect(() => {
+    if (!!searchKeyWord.length)
+      userApi
+        .searches(userId, { nickname: searchKeyWord })
+        .then((res) => {
+          const response = res.data.data;
+          const isFollow = (() => {
+            if (userId == response.userId) return "";
+            let type = response.isFollow;
+            if (type == "EMPTY") return "친구 신청";
+            else if (type == "REQUESTED") return "취소";
+            else if (type == "FOLLOW") return "삭제";
+          })();
+          setSearchFriend([{ ...response, isFollow }]);
+        })
+        .catch((err) => console.error(err));
+  }, [debounceKeyword]);
 
   const friendCheck = (friend: MyFriendListType) => {
     if (friend.followId) {
@@ -38,6 +59,10 @@ const MyFriendFrame = ({ title, search, friendList }: Props) => {
     } else if (friend.followRequestId) return { id: friend.followRequestId, isFollow: "요청" };
     else return { id: friend.userId, isFollow: friend.isFollow };
   };
+
+  const followList: (followerType | followingType | followRequestType | friendSearchType)[] = search
+    ? searchFriend
+    : friendList!;
 
   return (
     <div className={styles["friend__frame"]}>
@@ -48,8 +73,8 @@ const MyFriendFrame = ({ title, search, friendList }: Props) => {
         <Input types="search" value={searchKeyWord} onChange={onChangeHandler} placeholder="사용자 닉네임으로 검색" />
       )}
       <div className={styles["friend__frame__list"]}>
-        {friendList && friendList.length > 0 ? (
-          friendList.map((item, index) => {
+        {followList && followList.length > 0 ? (
+          followList.map((item, index) => {
             const { id, isFollow } = friendCheck(item);
             const followInfo = {
               nickname: item.nickname,

--- a/FE/src/components/mypage/details/friend/MyFriendFrame.tsx
+++ b/FE/src/components/mypage/details/friend/MyFriendFrame.tsx
@@ -3,7 +3,14 @@ import styles from "@styles/mypage/MyPage.module.scss";
 import Text from "@components/common/Text";
 import Input from "@components/common/Input";
 import FriendProfile, { ProfileConfig } from "@components/common/FriendProfile";
-import { followerType, followingType, followRequestType, friendInfo, friendSearchType } from "@util/friend.interface";
+import {
+  followerType,
+  followingType,
+  followRequestType,
+  followType,
+  friendInfo,
+  friendSearchType,
+} from "@util/friend.interface";
 import { selectUserId } from "@store/authSlice";
 import { useAppSelector } from "@hooks/hook";
 import { userApi } from "@api/Api";
@@ -15,7 +22,7 @@ interface MyFriendListType extends friendInfo {
   followRequestId?: number;
   receiveId?: number;
   userId?: number;
-  isFollow?: "삭제" | "친구 신청" | "팔로워 신청" | "요청" | "취소";
+  isFollow?: followType["types"];
 }
 
 interface Props {
@@ -41,12 +48,12 @@ const MyFriendFrame = ({ title, search, friendList }: Props) => {
         .searches(userId, { nickname: searchKeyWord })
         .then((res) => {
           const response = res.data.data;
-          const isFollow = (() => {
+          const isFollow: friendSearchType["isFollow"] | "" = (() => {
             if (userId == response.userId) return "";
             let type = response.isFollow;
             if (type == "EMPTY") return "친구 신청";
             else if (type == "REQUESTED") return "취소";
-            else if (type == "FOLLOW") return "삭제";
+            else return "팔로잉 삭제";
           })();
           setSearchFriend([{ ...response, isFollow }]);
         })
@@ -60,7 +67,7 @@ const MyFriendFrame = ({ title, search, friendList }: Props) => {
   const friendCheck = (friend: MyFriendListType) => {
     if (friend.followId) {
       if (friend.isFollow) return { id: friend.followId, isFollow: friend.isFollow }; // 팔로워 목록
-      else return { id: friend.followId, isFollow: "삭제" }; // 팔로잉 목록
+      else return { id: friend.followId, isFollow: "팔로잉 삭제" }; // 팔로잉 목록
     } else if (friend.followRequestId) return { id: friend.followRequestId, isFollow: "요청" }; // 팔로우 요청
     else return { id: friend.userId, isFollow: friend.isFollow }; // 친구 검색
   };
@@ -87,13 +94,7 @@ const MyFriendFrame = ({ title, search, friendList }: Props) => {
               message: item.statusMessage,
               src: item.profileImage,
             };
-            return (
-              <FriendProfile
-                key={id}
-                types={isFollow as "삭제" | "친구 신청" | "팔로워 신청" | "요청" | "취소"}
-                profile={followInfo}
-              />
-            );
+            return <FriendProfile key={id} types={isFollow as followType["types"]} profile={followInfo} />;
           })
         ) : (
           <Text types="small">{search ? alertMessage : `${title}이(가) 없습니다.`}</Text>

--- a/FE/src/components/mypage/details/friend/MyFriendFrame.tsx
+++ b/FE/src/components/mypage/details/friend/MyFriendFrame.tsx
@@ -100,13 +100,7 @@ const MyFriendFrame = ({ title, search, friendList }: Props) => {
               message: item.statusMessage,
               src: item.profileImage,
             };
-            return (
-              <FriendProfile
-                key={isFollow?.concat(id!.toString())}
-                types={isFollow as followType["types"]}
-                profile={followInfo}
-              />
-            );
+            return <FriendProfile key={title + id} types={isFollow as followType["types"]} profile={followInfo} />;
           })
         ) : (
           <Text types="small">{search ? alertMessage : `${title}이(가) 없습니다.`}</Text>

--- a/FE/src/components/mypage/details/friend/MyFriendFrame.tsx
+++ b/FE/src/components/mypage/details/friend/MyFriendFrame.tsx
@@ -71,8 +71,10 @@ const MyFriendFrame = ({ title, search, friendList }: Props) => {
         })
         .catch((err) => {
           const response = err.response.data;
-          if (response.code == "NOT_FOUND_NICKNAME") setAlertMessage("일치하는 닉네임을 찾을 수 없습니다.");
-          else console.error(err);
+          if (response.code == "NOT_FOUND_NICKNAME") {
+            setSearchFriend([]);
+            setAlertMessage("일치하는 닉네임을 찾을 수 없습니다.");
+          } else console.error(err);
         });
   }, [debounceKeyword, followState]);
 

--- a/FE/src/components/mypage/details/friend/MyFriendFrame.tsx
+++ b/FE/src/components/mypage/details/friend/MyFriendFrame.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import styles from "@styles/mypage/MyPage.module.scss";
 import Text from "@components/common/Text";
 import Input from "@components/common/Input";
-import FriendProfile from "@components/common/FriendProfile";
+import FriendProfile, { ProfileConfig } from "@components/common/FriendProfile";
 import { followerType, followingType, followRequestType, friendInfo, friendSearchType } from "@util/friend.interface";
 import { selectUserId } from "@store/authSlice";
 import { useAppSelector } from "@hooks/hook";
@@ -59,10 +59,10 @@ const MyFriendFrame = ({ title, search, friendList }: Props) => {
 
   const friendCheck = (friend: MyFriendListType) => {
     if (friend.followId) {
-      if (friend.isFollow) return { id: friend.followId, isFollow: friend.isFollow };
-      else return { id: friend.followId, isFollow: "삭제" };
-    } else if (friend.followRequestId) return { id: friend.followRequestId, isFollow: "요청" };
-    else return { id: friend.userId, isFollow: friend.isFollow };
+      if (friend.isFollow) return { id: friend.followId, isFollow: friend.isFollow }; // 팔로워 목록
+      else return { id: friend.followId, isFollow: "삭제" }; // 팔로잉 목록
+    } else if (friend.followRequestId) return { id: friend.followRequestId, isFollow: "요청" }; // 팔로우 요청
+    else return { id: friend.userId, isFollow: friend.isFollow }; // 친구 검색
   };
 
   const followList: (followerType | followingType | followRequestType | friendSearchType)[] = search
@@ -81,7 +81,8 @@ const MyFriendFrame = ({ title, search, friendList }: Props) => {
         {followList && followList.length > 0 ? (
           followList.map((item, index) => {
             const { id, isFollow } = friendCheck(item);
-            const followInfo = {
+            const followInfo: ProfileConfig = {
+              userId: id!,
               nickname: item.nickname,
               message: item.statusMessage,
               src: item.profileImage,

--- a/FE/src/components/mypage/details/friend/MyFriendFrame.tsx
+++ b/FE/src/components/mypage/details/friend/MyFriendFrame.tsx
@@ -1,0 +1,75 @@
+import React, { useEffect, useState } from "react";
+import styles from "@styles/mypage/MyPage.module.scss";
+import Text from "@components/common/Text";
+import Input from "@components/common/Input";
+import FriendProfile from "@components/common/FriendProfile";
+import { followerType, followingType, followRequestType } from "@util/friend.interface";
+
+interface MyFriendListType {
+  followId?: number;
+  followerId?: number;
+  followRequestId?: number;
+  receiveId?: number;
+  userId?: number;
+  email: string;
+  nickname: string;
+  profileImage: string;
+  statusMessage: string;
+  isFollow?: "삭제" | "친구 신청" | "팔로워 신청" | "요청" | "취소";
+}
+
+interface Props {
+  title: string;
+  search?: boolean;
+  friendList?: (followerType | followingType | followRequestType)[];
+}
+
+const MyFriendFrame = ({ title, search, friendList }: Props) => {
+  const [searchKeyWord, setSearchKeyWord] = useState("");
+
+  const onChangeHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchKeyWord(e.target.value);
+  };
+
+  const friendCheck = (friend: MyFriendListType) => {
+    if (friend.followId) {
+      if (friend.isFollow) return { id: friend.followId, isFollow: friend.isFollow };
+      else return { id: friend.followId, isFollow: "삭제" };
+    } else if (friend.followRequestId) return { id: friend.followRequestId, isFollow: "요청" };
+    else return { id: friend.userId, isFollow: friend.isFollow };
+  };
+
+  return (
+    <div className={styles["friend__frame"]}>
+      <div className={styles["friend__frame__title"]}>
+        <Text bold>{title}</Text>
+      </div>
+      {search && (
+        <Input types="search" value={searchKeyWord} onChange={onChangeHandler} placeholder="사용자 닉네임으로 검색" />
+      )}
+      <div className={styles["friend__frame__list"]}>
+        {friendList && friendList.length > 0 ? (
+          friendList.map((item, index) => {
+            const { id, isFollow } = friendCheck(item);
+            const followInfo = {
+              nickname: item.nickname,
+              message: item.statusMessage,
+              src: item.profileImage,
+            };
+            return (
+              <FriendProfile
+                key={id}
+                types={isFollow as "삭제" | "친구 신청" | "팔로워 신청" | "요청" | "취소"}
+                profile={followInfo}
+              />
+            );
+          })
+        ) : (
+          <Text types="small">{title}이(가) 없습니다.</Text>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default MyFriendFrame;

--- a/FE/src/components/mypage/details/friend/MyFriendFrame.tsx
+++ b/FE/src/components/mypage/details/friend/MyFriendFrame.tsx
@@ -88,7 +88,7 @@ const MyFriendFrame = ({ title, search, friendList }: Props) => {
       )}
       <div className={styles["friend__frame__list"]}>
         {followList && followList.length > 0 ? (
-          followList.map((item, index) => {
+          followList.map((item) => {
             const { id, isFollow } = friendCheck(item);
             const followInfo: ProfileConfig = {
               userId: id!,
@@ -96,7 +96,13 @@ const MyFriendFrame = ({ title, search, friendList }: Props) => {
               message: item.statusMessage,
               src: item.profileImage,
             };
-            return <FriendProfile key={id} types={isFollow as followType["types"]} profile={followInfo} />;
+            return (
+              <FriendProfile
+                key={isFollow?.concat(id!.toString())}
+                types={isFollow as followType["types"]}
+                profile={followInfo}
+              />
+            );
           })
         ) : (
           <Text types="small">{search ? alertMessage : `${title}이(가) 없습니다.`}</Text>

--- a/FE/src/components/mypage/details/friend/MyFriendFrame.tsx
+++ b/FE/src/components/mypage/details/friend/MyFriendFrame.tsx
@@ -36,7 +36,7 @@ const MyFriendFrame = ({ title, search, friendList }: Props) => {
   const [searchFriend, setSearchFriend] = useState<friendSearchType[]>([]);
   const [searchKeyWord, setSearchKeyWord] = useState("");
   const debounceKeyword = useDebounce(searchKeyWord, 400);
-  const [alertMessage, setAlertMessage] = useState("닉네임을 통해 검색이 가능합니다.");
+  const [alertMessage, setAlertMessage] = useState("");
   const followState: boolean = useAppSelector(selectFollowState);
 
   const onChangeHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -49,6 +49,10 @@ const MyFriendFrame = ({ title, search, friendList }: Props) => {
     if (search && "FOLLOW") return "팔로잉 삭제";
     return "팔로워 삭제";
   };
+
+  useEffect(() => {
+    if (!debounceKeyword.length) setAlertMessage("닉네임을 통해 검색이 가능합니다.");
+  }, [debounceKeyword.length]);
 
   useEffect(() => {
     if (!search) {

--- a/FE/src/components/mypage/details/friend/MyFriendFrame.tsx
+++ b/FE/src/components/mypage/details/friend/MyFriendFrame.tsx
@@ -41,18 +41,22 @@ const MyFriendFrame = ({ title, search, friendList }: Props) => {
     setSearchKeyWord(e.target.value);
   };
 
+  const typeToFollow = (type: string) => {
+    if (type == "EMPTY") return "친구 신청";
+    if (type == "REQUESTED") return "취소";
+    if (search && "FOLLOW") return "팔로잉 삭제";
+    return "팔로워 삭제";
+  };
+
   useEffect(() => {
     if (!!searchKeyWord.length)
       userApi
         .searches(userId, { nickname: searchKeyWord })
         .then((res) => {
           const response = res.data.data;
-          const isFollow: friendSearchType["isFollow"] | "" = (() => {
+          const isFollow = (() => {
             if (userId == response.userId) return "";
-            let type = response.isFollow;
-            if (type == "EMPTY") return "친구 신청";
-            else if (type == "REQUESTED") return "취소";
-            else return "팔로잉 삭제";
+            return typeToFollow(response.isFollow);
           })();
           setSearchFriend([{ ...response, isFollow }]);
         })
@@ -67,7 +71,7 @@ const MyFriendFrame = ({ title, search, friendList }: Props) => {
     if (friend.followerId)
       return {
         id: friend.followerId,
-        isFollow: friend.isFollow || "팔로워 삭제", // isFollow 누락, API 수정후 변경 예정
+        isFollow: typeToFollow(friend.isFollow || "FOLLOW"), // isFollow 누락, API 수정후 변경 예정
       };
     else if (friend.followingId) return { id: friend.followingId, isFollow: "팔로잉 삭제" };
     else if (friend.requesterId) return { id: friend.requesterId, isFollow: "요청" };

--- a/FE/src/components/mypage/details/friend/MyFriendFrame.tsx
+++ b/FE/src/components/mypage/details/friend/MyFriendFrame.tsx
@@ -64,10 +64,14 @@ const MyFriendFrame = ({ title, search, friendList }: Props) => {
   }, [debounceKeyword]);
 
   const friendCheck = (friend: MyFriendListType) => {
-    if (friend.followerId) return { id: friend.followerId, isFollow: friend.isFollow || "팔로워 삭제" };
-    else if (friend.followingId) return { id: friend.followingId, isFollow: "팔로잉 삭제" }; // 팔로잉 목록
-    else if (friend.requesterId) return { id: friend.requesterId, isFollow: "요청" }; // 팔로우 요청
-    else return { id: friend.userId, isFollow: friend.isFollow }; // 친구 검색
+    if (friend.followerId)
+      return {
+        id: friend.followerId,
+        isFollow: friend.isFollow || "팔로워 삭제", // isFollow 누락, API 수정후 변경 예정
+      };
+    else if (friend.followingId) return { id: friend.followingId, isFollow: "팔로잉 삭제" };
+    else if (friend.requesterId) return { id: friend.requesterId, isFollow: "요청" };
+    else return { id: friend.userId, isFollow: friend.isFollow };
   };
 
   const followList: (followerType | followingType | followRequestType | friendSearchType)[] = search

--- a/FE/src/components/mypage/details/friend/MyFriendFrame.tsx
+++ b/FE/src/components/mypage/details/friend/MyFriendFrame.tsx
@@ -51,6 +51,13 @@ const MyFriendFrame = ({ title, search, friendList }: Props) => {
   };
 
   useEffect(() => {
+    if (!search) {
+      setSearchKeyWord("");
+      setSearchFriend([]);
+    }
+  }, [search]);
+
+  useEffect(() => {
     if (!!searchKeyWord.length)
       userApi
         .searches(userId, { nickname: searchKeyWord })

--- a/FE/src/components/mypage/details/friend/MyFriendFrame.tsx
+++ b/FE/src/components/mypage/details/friend/MyFriendFrame.tsx
@@ -20,7 +20,7 @@ interface MyFriendListType extends friendInfo {
   followId?: number;
   followerId?: number;
   followRequestId?: number;
-  receiveId?: number;
+  requesterId?: number;
   userId?: number;
   isFollow?: followType["types"];
 }
@@ -68,7 +68,7 @@ const MyFriendFrame = ({ title, search, friendList }: Props) => {
     if (friend.followId) {
       if (friend.isFollow) return { id: friend.followId, isFollow: friend.isFollow }; // 팔로워 목록
       else return { id: friend.followId, isFollow: "팔로잉 삭제" }; // 팔로잉 목록
-    } else if (friend.followRequestId) return { id: friend.followRequestId, isFollow: "요청" }; // 팔로우 요청
+    } else if (friend.requesterId) return { id: friend.requesterId, isFollow: "요청" }; // 팔로우 요청
     else return { id: friend.userId, isFollow: friend.isFollow }; // 친구 검색
   };
 

--- a/FE/src/components/mypage/details/friend/MyFriendFrame.tsx
+++ b/FE/src/components/mypage/details/friend/MyFriendFrame.tsx
@@ -29,6 +29,7 @@ const MyFriendFrame = ({ title, search, friendList }: Props) => {
   const [searchFriend, setSearchFriend] = useState<friendSearchType[]>([]);
   const [searchKeyWord, setSearchKeyWord] = useState("");
   const debounceKeyword = useDebounce(searchKeyWord, 500);
+  const [alertMessage, setAlertMessage] = useState("닉네임을 통해 검색이 가능합니다.");
 
   const onChangeHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
     setSearchKeyWord(e.target.value);
@@ -49,7 +50,11 @@ const MyFriendFrame = ({ title, search, friendList }: Props) => {
           })();
           setSearchFriend([{ ...response, isFollow }]);
         })
-        .catch((err) => console.error(err));
+        .catch((err) => {
+          const response = err.response.data;
+          if (response.code == "NOT_FOUND_NICKNAME") setAlertMessage("일치하는 닉네임을 찾을 수 없습니다.");
+          else console.error(err);
+        });
   }, [debounceKeyword]);
 
   const friendCheck = (friend: MyFriendListType) => {
@@ -90,7 +95,7 @@ const MyFriendFrame = ({ title, search, friendList }: Props) => {
             );
           })
         ) : (
-          <Text types="small">{title}이(가) 없습니다.</Text>
+          <Text types="small">{search ? alertMessage : `${title}이(가) 없습니다.`}</Text>
         )}
       </div>
     </div>

--- a/FE/src/components/mypage/details/friend/MyFriendFrame.tsx
+++ b/FE/src/components/mypage/details/friend/MyFriendFrame.tsx
@@ -51,7 +51,10 @@ const MyFriendFrame = ({ title, search, friendList }: Props) => {
   };
 
   useEffect(() => {
-    if (!debounceKeyword.length) setAlertMessage("닉네임을 통해 검색이 가능합니다.");
+    if (!debounceKeyword.length) {
+      setSearchFriend([]);
+      setAlertMessage("닉네임을 통해 검색이 가능합니다.");
+    }
   }, [debounceKeyword.length]);
 
   useEffect(() => {

--- a/FE/src/components/mypage/details/friend/MyFriendFrame.tsx
+++ b/FE/src/components/mypage/details/friend/MyFriendFrame.tsx
@@ -17,9 +17,8 @@ import { userApi } from "@api/Api";
 import { useDebounce } from "@util/EventControlModule";
 
 interface MyFriendListType extends friendInfo {
-  followId?: number;
   followerId?: number;
-  followRequestId?: number;
+  followingId?: number;
   requesterId?: number;
   userId?: number;
   isFollow?: followType["types"];
@@ -65,10 +64,9 @@ const MyFriendFrame = ({ title, search, friendList }: Props) => {
   }, [debounceKeyword]);
 
   const friendCheck = (friend: MyFriendListType) => {
-    if (friend.followId) {
-      if (friend.isFollow) return { id: friend.followId, isFollow: friend.isFollow }; // 팔로워 목록
-      else return { id: friend.followId, isFollow: "팔로잉 삭제" }; // 팔로잉 목록
-    } else if (friend.requesterId) return { id: friend.requesterId, isFollow: "요청" }; // 팔로우 요청
+    if (friend.followerId) return { id: friend.followerId, isFollow: friend.isFollow || "팔로워 삭제" };
+    else if (friend.followingId) return { id: friend.followingId, isFollow: "팔로잉 삭제" }; // 팔로잉 목록
+    else if (friend.requesterId) return { id: friend.requesterId, isFollow: "요청" }; // 팔로우 요청
     else return { id: friend.userId, isFollow: friend.isFollow }; // 친구 검색
   };
 

--- a/FE/src/components/mypage/details/friend/MyFriendFrame.tsx
+++ b/FE/src/components/mypage/details/friend/MyFriendFrame.tsx
@@ -15,6 +15,7 @@ import { selectUserId } from "@store/authSlice";
 import { useAppSelector } from "@hooks/hook";
 import { userApi } from "@api/Api";
 import { useDebounce } from "@util/EventControlModule";
+import { selectFollowState } from "@store/friendSlice";
 
 interface MyFriendListType extends friendInfo {
   followerId?: number;
@@ -34,8 +35,9 @@ const MyFriendFrame = ({ title, search, friendList }: Props) => {
   const userId: number = useAppSelector(selectUserId);
   const [searchFriend, setSearchFriend] = useState<friendSearchType[]>([]);
   const [searchKeyWord, setSearchKeyWord] = useState("");
-  const debounceKeyword = useDebounce(searchKeyWord, 500);
+  const debounceKeyword = useDebounce(searchKeyWord, 400);
   const [alertMessage, setAlertMessage] = useState("닉네임을 통해 검색이 가능합니다.");
+  const followState: boolean = useAppSelector(selectFollowState);
 
   const onChangeHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
     setSearchKeyWord(e.target.value);
@@ -65,7 +67,7 @@ const MyFriendFrame = ({ title, search, friendList }: Props) => {
           if (response.code == "NOT_FOUND_NICKNAME") setAlertMessage("일치하는 닉네임을 찾을 수 없습니다.");
           else console.error(err);
         });
-  }, [debounceKeyword]);
+  }, [debounceKeyword, followState]);
 
   const friendCheck = (friend: MyFriendListType) => {
     if (friend.followerId)

--- a/FE/src/components/planner/day/CustomCursor.tsx
+++ b/FE/src/components/planner/day/CustomCursor.tsx
@@ -2,20 +2,7 @@ import React, { useRef } from "react";
 import styles from "@styles/planner/day.module.scss";
 import { useAppSelector } from "@hooks/hook";
 import { BASIC_CATEGORY_ITEM, selectTodoItem } from "@store/planner/daySlice";
-
-const throttle = <T extends (...args: any[]) => any>(fn: T, delay: number) => {
-  let timeId: ReturnType<typeof setTimeout> | null;
-  return (...args: Parameters<T>) => {
-    let result: any;
-    if (!timeId) {
-      timeId = setTimeout(() => {
-        result = fn(...args);
-        timeId = null;
-      }, delay);
-      return result;
-    }
-  };
-};
+import { throttle } from "@util/eventControlModule";
 
 const CustomCursor = () => {
   const cursorRef = useRef<SVGSVGElement>(null);

--- a/FE/src/components/planner/day/CustomCursor.tsx
+++ b/FE/src/components/planner/day/CustomCursor.tsx
@@ -2,7 +2,7 @@ import React, { useRef } from "react";
 import styles from "@styles/planner/day.module.scss";
 import { useAppSelector } from "@hooks/hook";
 import { BASIC_CATEGORY_ITEM, selectTodoItem } from "@store/planner/daySlice";
-import { throttle } from "@util/eventControlModule";
+import { throttle } from "@util/EventControlModule";
 
 const CustomCursor = () => {
   const cursorRef = useRef<SVGSVGElement>(null);

--- a/FE/src/components/planner/day/todo/TimeTable.tsx
+++ b/FE/src/components/planner/day/todo/TimeTable.tsx
@@ -16,6 +16,7 @@ import isSameOrAfter from "dayjs/plugin/isSameOrAfter";
 import { TodoConfig } from "@util/planner.interface";
 import { plannerApi } from "@api/Api";
 import { selectUserId } from "@store/authSlice";
+import { debouncing } from "@util/eventControlModule";
 dayjs.extend(isSameOrBefore);
 dayjs.extend(isSameOrAfter);
 
@@ -30,18 +31,6 @@ interface tableTimeType {
   time: string;
   closeButton?: boolean;
 }
-
-const debouncing = <T extends (...args: any[]) => any>(fn: T, delay: number) => {
-  let timeId: ReturnType<typeof setTimeout>;
-  return (...args: Parameters<T>): ReturnType<T> => {
-    let result: any;
-    if (timeId) clearTimeout(timeId);
-    timeId = setTimeout(() => {
-      result = fn(...args);
-    }, delay);
-    return result;
-  };
-};
 
 const TimeTable = ({ clicked, setClicked }: Props) => {
   const dispatch = useAppDispatch();

--- a/FE/src/components/planner/day/todo/TimeTable.tsx
+++ b/FE/src/components/planner/day/todo/TimeTable.tsx
@@ -15,8 +15,9 @@ import isSameOrBefore from "dayjs/plugin/isSameOrBefore";
 import isSameOrAfter from "dayjs/plugin/isSameOrAfter";
 import { TodoConfig } from "@util/planner.interface";
 import { plannerApi } from "@api/Api";
+import { debouncing } from "@util/EventControlModule";
 import { selectUserId } from "@store/authSlice";
-import { debouncing } from "@util/eventControlModule";
+
 dayjs.extend(isSameOrBefore);
 dayjs.extend(isSameOrAfter);
 

--- a/FE/src/components/planner/month/MonthFriends.tsx
+++ b/FE/src/components/planner/month/MonthFriends.tsx
@@ -5,14 +5,14 @@ import { profileInfo } from "@pages/commonPage";
 import FriendProfile, { ProfileConfig } from "@components/common/FriendProfile";
 
 const FRIENDS_LIST: ProfileConfig[] = [
-  { src: "", nickname: "토롱이", message: "인생은 생각하는대로 흘러간다." },
-  { src: "", nickname: "yyyysu", message: "아좌아좌~" },
-  { src: "", nickname: "곰돌이 푸", message: "오늘 점심은 꿀이다" },
-  { src: "", nickname: "mung", message: "멍멍이는 멍멍하지" },
-  { src: "", nickname: "mung", message: "멍멍이는 멍멍하지" },
-  { src: "", nickname: "mung", message: "멍멍이는 멍멍하지" },
-  { src: "", nickname: "mung", message: "멍멍이는 멍멍하지" },
-  { src: "", nickname: "mung", message: "멍멍이는 멍멍하지" },
+  { userId: 0, src: "", nickname: "토롱이", message: "인생은 생각하는대로 흘러간다." },
+  { userId: 0, src: "", nickname: "yyyysu", message: "아좌아좌~" },
+  { userId: 0, src: "", nickname: "곰돌이 푸", message: "오늘 점심은 꿀이다" },
+  { userId: 0, src: "", nickname: "mung", message: "멍멍이는 멍멍하지" },
+  { userId: 0, src: "", nickname: "mung", message: "멍멍이는 멍멍하지" },
+  { userId: 0, src: "", nickname: "mung", message: "멍멍이는 멍멍하지" },
+  { userId: 0, src: "", nickname: "mung", message: "멍멍이는 멍멍하지" },
+  { userId: 0, src: "", nickname: "mung", message: "멍멍이는 멍멍하지" },
 ];
 
 const MonthFriends = () => {

--- a/FE/src/hooks/configStore.ts
+++ b/FE/src/hooks/configStore.ts
@@ -4,6 +4,7 @@ import monthReducer from "@store/planner/monthSlice";
 import weekReducer from "@store/planner/weekSlice";
 import dayReducer from "@store/planner/daySlice";
 import mypageReducer from "@store/mypageSlice";
+import frinedReducer from "@store/friendSlice";
 
 import { persistReducer } from "redux-persist";
 import storage from "redux-persist/lib/storage";
@@ -15,6 +16,7 @@ const rootReducer = combineReducers({
   week: weekReducer,
   day: dayReducer,
   mypage: mypageReducer,
+  friend: frinedReducer,
 });
 
 const persistConfig = {

--- a/FE/src/pages/commonPage.tsx
+++ b/FE/src/pages/commonPage.tsx
@@ -48,7 +48,7 @@ const commonPage = () => {
       <div>
         <FriendProfile types="기본" profile={profileInfo} />
         <FriendProfile types="아이콘" profile={profileInfo} />
-        <FriendProfile types="삭제" profile={profileInfo} />
+        <FriendProfile types="팔로워 삭제" profile={profileInfo} />
         <FriendProfile types="친구 신청" profile={profileInfo} />
         <FriendProfile types="팔로워 신청" profile={profileInfo} />
         <FriendProfile types="요청" profile={profileInfo} />

--- a/FE/src/pages/commonPage.tsx
+++ b/FE/src/pages/commonPage.tsx
@@ -7,6 +7,7 @@ import FriendProfile, { ProfileConfig } from "@components/common/FriendProfile";
 import Profile from "@components/common/Profile";
 
 export const profileInfo: ProfileConfig = {
+  userId: 0,
   nickname: "ribbonE",
   message: "방가방가",
   src: "https://avatars.githubusercontent.com/u/85155789?v=4",

--- a/FE/src/store/friendSlice.ts
+++ b/FE/src/store/friendSlice.ts
@@ -1,0 +1,24 @@
+import { PayloadAction, createSlice } from "@reduxjs/toolkit";
+import { rootState } from "@hooks/configStore";
+
+interface friendConfig {
+  followState: number;
+}
+
+const initialState: friendConfig = {
+  followState: 0,
+};
+
+const friendSlice = createSlice({
+  name: "friend",
+  initialState,
+  reducers: {
+    setFollowState: (state, { payload }: PayloadAction<friendConfig>) => {
+      state.followState = payload.followState;
+    },
+  },
+});
+
+export const { setFollowState } = friendSlice.actions;
+export const selectFollowState = (state: rootState) => state.friend.followState;
+export default friendSlice.reducer;

--- a/FE/src/styles/mypage/MyPage.module.scss
+++ b/FE/src/styles/mypage/MyPage.module.scss
@@ -516,11 +516,13 @@ $color-warning: var(--color-warning);
   }
 
   &__frame {
+    display: grid;
+    row-gap: 1em;
+
     &__title {
       padding: 1em;
       box-sizing: border-box;
       border-bottom: 1px solid $color-text;
-      margin-bottom: 1em;
     }
 
     &__list {

--- a/FE/src/util/EventControlModule.tsx
+++ b/FE/src/util/EventControlModule.tsx
@@ -1,3 +1,19 @@
+import { useEffect, useState } from "react";
+
+export function useDebounce(value: string, delay = 1000) {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => clearTimeout(handler);
+  }, [value]);
+
+  return debouncedValue;
+}
+
 export const debouncing = <T extends (...args: any[]) => any>(fn: T, delay: number) => {
   let timeId: ReturnType<typeof setTimeout>;
   return (...args: Parameters<T>): ReturnType<T> => {

--- a/FE/src/util/EventControlModule.tsx
+++ b/FE/src/util/EventControlModule.tsx
@@ -1,0 +1,25 @@
+export const debouncing = <T extends (...args: any[]) => any>(fn: T, delay: number) => {
+  let timeId: ReturnType<typeof setTimeout>;
+  return (...args: Parameters<T>): ReturnType<T> => {
+    let result: any;
+    if (timeId) clearTimeout(timeId);
+    timeId = setTimeout(() => {
+      result = fn(...args);
+    }, delay);
+    return result;
+  };
+};
+
+export const throttle = <T extends (...args: any[]) => any>(fn: T, delay: number) => {
+  let timeId: ReturnType<typeof setTimeout> | null;
+  return (...args: Parameters<T>) => {
+    let result: any;
+    if (!timeId) {
+      timeId = setTimeout(() => {
+        result = fn(...args);
+        timeId = null;
+      }, delay);
+      return result;
+    }
+  };
+};

--- a/FE/src/util/data/DayTodos.ts
+++ b/FE/src/util/data/DayTodos.ts
@@ -1,8 +1,10 @@
+import { ProfileConfig } from "@components/common/FriendProfile";
 import { CategoryConfig } from "@util/planner.interface";
 import { TodoConfig } from "@util/planner.interface";
 import dayjs from "dayjs";
 
-export const todoData_friend = {
+export const todoData_friend: ProfileConfig = {
+  userId: 0,
   nickname: "토롱이",
   message: "인생은 생각하는대로 흘러간다.",
   src: "https://avatars.githubusercontent.com/u/85155789?v=4",

--- a/FE/src/util/data/FriendData.ts
+++ b/FE/src/util/data/FriendData.ts
@@ -61,7 +61,7 @@ export const followerListData: followerType[] = [
 export const followingListData: followingType[] = [
   {
     followId: 1,
-    followerId: 5,
+    followingId: 5,
     email: "mung@todo.mate",
     nickname: "mung",
     profileImage: "https://github.com/NewSainTurtle/ShadowMate/assets/83412032/9e66fca0-45bd-4708-8ea7-0dc5baca0acf",
@@ -69,7 +69,7 @@ export const followingListData: followingType[] = [
   },
   {
     followId: 2,
-    followerId: 6,
+    followingId: 6,
     email: "냥냥@todo.mate",
     nickname: "냥냥",
     profileImage: "https://github.com/NewSainTurtle/ShadowMate/assets/83412032/dbb27de8-a9ce-4fc3-a495-302a6b62c34e",
@@ -77,7 +77,7 @@ export const followingListData: followingType[] = [
   },
   {
     followId: 3,
-    followerId: 7,
+    followingId: 7,
     email: "세계@todo.mate",
     nickname: "세계평화",
     profileImage: "https://github.com/NewSainTurtle/ShadowMate/assets/83412032/4effef28-b7ea-4c77-90bb-6c570c4c66cd",

--- a/FE/src/util/data/FriendData.ts
+++ b/FE/src/util/data/FriendData.ts
@@ -66,6 +66,7 @@ export const followingListData: followingType[] = [
     nickname: "mung",
     profileImage: "https://github.com/NewSainTurtle/ShadowMate/assets/83412032/9e66fca0-45bd-4708-8ea7-0dc5baca0acf",
     statusMessage: "멍멍이는 멍멍하지",
+    isFollow: "삭제",
   },
   {
     followId: 2,
@@ -74,6 +75,7 @@ export const followingListData: followingType[] = [
     nickname: "냥냥",
     profileImage: "https://github.com/NewSainTurtle/ShadowMate/assets/83412032/dbb27de8-a9ce-4fc3-a495-302a6b62c34e",
     statusMessage: "냥냥이은 냥냥하다",
+    isFollow: "삭제",
   },
   {
     followId: 3,
@@ -82,6 +84,7 @@ export const followingListData: followingType[] = [
     nickname: "세계평화",
     profileImage: "https://github.com/NewSainTurtle/ShadowMate/assets/83412032/4effef28-b7ea-4c77-90bb-6c570c4c66cd",
     statusMessage: "세계 정복을 목표로 공부하기",
+    isFollow: "삭제",
   },
 ];
 
@@ -93,6 +96,7 @@ export const followRequestData: followRequestType[] = [
     profileImage: "https://github.com/NewSainTurtle/ShadowMate/assets/83412032/9e66fca0-45bd-4708-8ea7-0dc5baca0acf",
     statusMessage: "멍멍이는 멍멍하지",
     receiveId: 5,
+    isFollow: "요청",
   },
   {
     followRequestId: 2,
@@ -101,6 +105,7 @@ export const followRequestData: followRequestType[] = [
     profileImage: "https://github.com/NewSainTurtle/ShadowMate/assets/83412032/dbb27de8-a9ce-4fc3-a495-302a6b62c34e",
     statusMessage: "냥냥이은 냥냥하다",
     receiveId: 6,
+    isFollow: "요청",
   },
   {
     followRequestId: 3,
@@ -109,6 +114,7 @@ export const followRequestData: followRequestType[] = [
     profileImage: "https://github.com/NewSainTurtle/ShadowMate/assets/83412032/4effef28-b7ea-4c77-90bb-6c570c4c66cd",
     statusMessage: "세계 정복을 목표로 공부하기",
     receiveId: 7,
+    isFollow: "요청",
   },
 ];
 
@@ -127,7 +133,7 @@ export const FriendSearch: friendSearchType[] = [
     nickname: "토롱이",
     profileImage: "https://github.com/NewSainTurtle/ShadowMate/assets/83412032/d4ee7bff-299f-49de-a372-91b7a15076d2",
     statusMessage: "인생은 생각하는대로 흘러간다.",
-    isFollow: "삭제",
+    isFollow: "친구 신청",
   },
   {
     userId: 3,
@@ -135,7 +141,7 @@ export const FriendSearch: friendSearchType[] = [
     nickname: "곰돌이 푸",
     profileImage: "https://github.com/NewSainTurtle/ShadowMate/assets/83412032/56212d87-c2e8-44c8-ac40-53e3a0b55e47",
     statusMessage: "오늘 점심은 꿀이다",
-    isFollow: "팔로워 신청",
+    isFollow: "친구 신청",
   },
   {
     userId: 1,
@@ -151,7 +157,7 @@ export const FriendSearch: friendSearchType[] = [
     nickname: "냥냥",
     profileImage: "https://github.com/NewSainTurtle/ShadowMate/assets/83412032/dbb27de8-a9ce-4fc3-a495-302a6b62c34e",
     statusMessage: "냥냥이은 냥냥하다",
-    isFollow: "삭제",
+    isFollow: "친구 신청",
   },
   {
     userId: 3,
@@ -159,6 +165,6 @@ export const FriendSearch: friendSearchType[] = [
     nickname: "세계평화",
     profileImage: "https://github.com/NewSainTurtle/ShadowMate/assets/83412032/4effef28-b7ea-4c77-90bb-6c570c4c66cd",
     statusMessage: "세계 정복을 목표로 공부하기",
-    isFollow: "팔로워 신청",
+    isFollow: "취소",
   },
 ];

--- a/FE/src/util/data/FriendData.ts
+++ b/FE/src/util/data/FriendData.ts
@@ -66,7 +66,6 @@ export const followingListData: followingType[] = [
     nickname: "mung",
     profileImage: "https://github.com/NewSainTurtle/ShadowMate/assets/83412032/9e66fca0-45bd-4708-8ea7-0dc5baca0acf",
     statusMessage: "멍멍이는 멍멍하지",
-    isFollow: "삭제",
   },
   {
     followId: 2,
@@ -75,7 +74,6 @@ export const followingListData: followingType[] = [
     nickname: "냥냥",
     profileImage: "https://github.com/NewSainTurtle/ShadowMate/assets/83412032/dbb27de8-a9ce-4fc3-a495-302a6b62c34e",
     statusMessage: "냥냥이은 냥냥하다",
-    isFollow: "삭제",
   },
   {
     followId: 3,
@@ -84,7 +82,6 @@ export const followingListData: followingType[] = [
     nickname: "세계평화",
     profileImage: "https://github.com/NewSainTurtle/ShadowMate/assets/83412032/4effef28-b7ea-4c77-90bb-6c570c4c66cd",
     statusMessage: "세계 정복을 목표로 공부하기",
-    isFollow: "삭제",
   },
 ];
 
@@ -96,7 +93,6 @@ export const followRequestData: followRequestType[] = [
     profileImage: "https://github.com/NewSainTurtle/ShadowMate/assets/83412032/9e66fca0-45bd-4708-8ea7-0dc5baca0acf",
     statusMessage: "멍멍이는 멍멍하지",
     receiveId: 5,
-    isFollow: "요청",
   },
   {
     followRequestId: 2,
@@ -105,7 +101,6 @@ export const followRequestData: followRequestType[] = [
     profileImage: "https://github.com/NewSainTurtle/ShadowMate/assets/83412032/dbb27de8-a9ce-4fc3-a495-302a6b62c34e",
     statusMessage: "냥냥이은 냥냥하다",
     receiveId: 6,
-    isFollow: "요청",
   },
   {
     followRequestId: 3,
@@ -114,7 +109,6 @@ export const followRequestData: followRequestType[] = [
     profileImage: "https://github.com/NewSainTurtle/ShadowMate/assets/83412032/4effef28-b7ea-4c77-90bb-6c570c4c66cd",
     statusMessage: "세계 정복을 목표로 공부하기",
     receiveId: 7,
-    isFollow: "요청",
   },
 ];
 

--- a/FE/src/util/data/FriendData.ts
+++ b/FE/src/util/data/FriendData.ts
@@ -92,7 +92,7 @@ export const followRequestData: followRequestType[] = [
     nickname: "mung",
     profileImage: "https://github.com/NewSainTurtle/ShadowMate/assets/83412032/9e66fca0-45bd-4708-8ea7-0dc5baca0acf",
     statusMessage: "멍멍이는 멍멍하지",
-    receiveId: 5,
+    requesterId: 5,
   },
   {
     followRequestId: 2,
@@ -100,7 +100,7 @@ export const followRequestData: followRequestType[] = [
     nickname: "냥냥",
     profileImage: "https://github.com/NewSainTurtle/ShadowMate/assets/83412032/dbb27de8-a9ce-4fc3-a495-302a6b62c34e",
     statusMessage: "냥냥이은 냥냥하다",
-    receiveId: 6,
+    requesterId: 6,
   },
   {
     followRequestId: 3,
@@ -108,7 +108,7 @@ export const followRequestData: followRequestType[] = [
     nickname: "세계평화",
     profileImage: "https://github.com/NewSainTurtle/ShadowMate/assets/83412032/4effef28-b7ea-4c77-90bb-6c570c4c66cd",
     statusMessage: "세계 정복을 목표로 공부하기",
-    receiveId: 7,
+    requesterId: 7,
   },
 ];
 

--- a/FE/src/util/data/FriendData.ts
+++ b/FE/src/util/data/FriendData.ts
@@ -18,7 +18,7 @@ export const followerListData: followerType[] = [
     nickname: "토롱이",
     profileImage: "https://github.com/NewSainTurtle/ShadowMate/assets/83412032/d4ee7bff-299f-49de-a372-91b7a15076d2",
     statusMessage: "인생은 생각하는대로 흘러간다.",
-    isFollow: "삭제",
+    isFollow: "팔로워 삭제",
   },
   {
     followId: 3,
@@ -45,7 +45,7 @@ export const followerListData: followerType[] = [
     nickname: "토롱이",
     profileImage: "https://github.com/NewSainTurtle/ShadowMate/assets/83412032/d4ee7bff-299f-49de-a372-91b7a15076d2",
     statusMessage: "인생은 생각하는대로 흘러간다.",
-    isFollow: "삭제",
+    isFollow: "팔로워 삭제",
   },
   {
     followId: 6,

--- a/FE/src/util/data/SocialData.ts
+++ b/FE/src/util/data/SocialData.ts
@@ -6,6 +6,7 @@ export const socialListData = [
     socialImage: "https://github.com/NewSainTurtle/ShadowMate/assets/83412032/60ae99eb-a00c-4f74-9365-ff86d9893b51",
     dailyPlannerDay: "2023-06-23",
     user: {
+      userId: 0,
       nickname: "ribbonE",
       message: "방가방가",
       src: "https://github.com/NewSainTurtle/ShadowMate/assets/83412032/ad4b287b-3d15-4756-a476-06bab40cefaa",
@@ -16,6 +17,7 @@ export const socialListData = [
     socialImage: "https://github.com/NewSainTurtle/ShadowMate/assets/83412032/60ae99eb-a00c-4f74-9365-ff86d9893b51",
     dailyPlannerDay: "2023-06-23",
     user: {
+      userId: 0,
       nickname: "토롱이",
       message: "인생은 생각하는대로 흘러간다.",
       src: "https://github.com/NewSainTurtle/ShadowMate/assets/83412032/d4ee7bff-299f-49de-a372-91b7a15076d2",
@@ -26,6 +28,7 @@ export const socialListData = [
     socialImage: "https://github.com/NewSainTurtle/ShadowMate/assets/83412032/60ae99eb-a00c-4f74-9365-ff86d9893b51",
     dailyPlannerDay: "2023-06-23",
     user: {
+      userId: 0,
       nickname: "곰돌이 푸",
       message: "오늘 점심은 꿀이다",
       src: "https://github.com/NewSainTurtle/ShadowMate/assets/83412032/56212d87-c2e8-44c8-ac40-53e3a0b55e47",
@@ -36,6 +39,7 @@ export const socialListData = [
     socialImage: "https://github.com/NewSainTurtle/ShadowMate/assets/83412032/60ae99eb-a00c-4f74-9365-ff86d9893b51",
     dailyPlannerDay: "2023-06-23",
     user: {
+      userId: 0,
       nickname: "mung",
       message: "멍멍이는 멍멍하지",
       src: "https://github.com/NewSainTurtle/ShadowMate/assets/83412032/9e66fca0-45bd-4708-8ea7-0dc5baca0acf",
@@ -46,6 +50,7 @@ export const socialListData = [
     socialImage: "https://github.com/NewSainTurtle/ShadowMate/assets/83412032/60ae99eb-a00c-4f74-9365-ff86d9893b51",
     dailyPlannerDay: "2023-06-23",
     user: {
+      userId: 0,
       nickname: "냥냥",
       message: "뭐",
       src: "https://github.com/NewSainTurtle/ShadowMate/assets/83412032/dbb27de8-a9ce-4fc3-a495-302a6b62c34e",
@@ -56,6 +61,7 @@ export const socialListData = [
     socialImage: "https://github.com/NewSainTurtle/ShadowMate/assets/83412032/60ae99eb-a00c-4f74-9365-ff86d9893b51",
     dailyPlannerDay: "2023-06-23",
     user: {
+      userId: 0,
       nickname: "평화주의자",
       message: "매일매일 공부하기",
       src: "https://github.com/NewSainTurtle/ShadowMate/assets/83412032/4effef28-b7ea-4c77-90bb-6c570c4c66cd",

--- a/FE/src/util/friend.interface.ts
+++ b/FE/src/util/friend.interface.ts
@@ -1,34 +1,34 @@
 // 친구정보
-interface friendInfo {
+export interface friendInfo {
   email: string;
   nickname: string;
   profileImage: string;
   statusMessage: string;
 }
 
-interface isFollow {
-  isFollow: "취소" | "삭제" | "팔로워 신청";
-}
-
 // 팔로워 목록
-export interface followerType extends friendInfo, isFollow {
+export interface followerType extends friendInfo {
   followId: number;
   followerId: number;
+  isFollow: "취소" | "삭제" | "팔로워 신청";
 }
 
 // 팔로잉 목록
 export interface followingType extends friendInfo {
   followId: number;
   followerId: number;
+  isFollow: "삭제";
 }
 
 // 팔로우 요청 목록
 export interface followRequestType extends friendInfo {
   followRequestId: number;
   receiveId: number;
+  isFollow: "요청";
 }
 
 // 친구 검색
-export interface friendSearchType extends friendInfo, isFollow {
+export interface friendSearchType extends friendInfo {
   userId: number;
+  isFollow: "친구 신청" | "취소";
 }

--- a/FE/src/util/friend.interface.ts
+++ b/FE/src/util/friend.interface.ts
@@ -30,5 +30,5 @@ export interface followRequestType extends friendInfo {
 // 친구 검색
 export interface friendSearchType extends friendInfo {
   userId: number;
-  isFollow: "친구 신청" | "취소";
+  isFollow: "친구 신청" | "삭제" | "취소";
 }

--- a/FE/src/util/friend.interface.ts
+++ b/FE/src/util/friend.interface.ts
@@ -17,14 +17,12 @@ export interface followerType extends friendInfo {
 export interface followingType extends friendInfo {
   followId: number;
   followerId: number;
-  isFollow: "삭제";
 }
 
 // 팔로우 요청 목록
 export interface followRequestType extends friendInfo {
   followRequestId: number;
   receiveId: number;
-  isFollow: "요청";
 }
 
 // 친구 검색

--- a/FE/src/util/friend.interface.ts
+++ b/FE/src/util/friend.interface.ts
@@ -27,7 +27,7 @@ export interface followingType extends friendInfo {
 // 팔로우 요청 목록
 export interface followRequestType extends friendInfo {
   followRequestId: number;
-  receiveId: number;
+  requesterId: number;
 }
 
 // 친구 검색

--- a/FE/src/util/friend.interface.ts
+++ b/FE/src/util/friend.interface.ts
@@ -21,7 +21,7 @@ export interface followerType extends friendInfo {
 // 팔로잉 목록
 export interface followingType extends friendInfo {
   followId: number;
-  followerId: number;
+  followingId: number;
 }
 
 // 팔로우 요청 목록

--- a/FE/src/util/friend.interface.ts
+++ b/FE/src/util/friend.interface.ts
@@ -6,11 +6,16 @@ export interface friendInfo {
   statusMessage: string;
 }
 
+// 팔로우 목록에서 가능한 친구 프로필 타입
+export interface followType {
+  types: "팔로워 삭제" | "팔로잉 삭제" | "친구 신청" | "팔로워 신청" | "요청" | "취소";
+}
+
 // 팔로워 목록
 export interface followerType extends friendInfo {
   followId: number;
   followerId: number;
-  isFollow: "취소" | "삭제" | "팔로워 신청";
+  isFollow: "취소" | "팔로워 삭제" | "팔로워 신청";
 }
 
 // 팔로잉 목록
@@ -28,5 +33,5 @@ export interface followRequestType extends friendInfo {
 // 친구 검색
 export interface friendSearchType extends friendInfo {
   userId: number;
-  isFollow: "친구 신청" | "삭제" | "취소";
+  isFollow: "친구 신청" | "팔로잉 삭제" | "취소";
 }


### PR DESCRIPTION
close #264

## 어떤 이유로 MR를 하셨나요?

- [ ] test 코드 작성
- [x] feature 병합
- [ ] 버그 수정
- [x] 코드 개선
- [ ] 기타(아래에 자세한 내용 기입해주세요)

## 세부 내용 - 왜 해당 MR이 필요한지 자세하게 설명해주세요

- 마이페이지 친구 API 연결(전부 연결 O)
  - ⚠ 팔로워 목록 API에 isFollow 누락 돼서 3가지 상태 확인 불가능
  - ⚠팔로워, 팔로잉 목록 API에는 stateMessage, plannerAccessScope 누락 돼서 확인 불가능
  - (누락된 부분은 API 수정 이후 새 이슈로 추가 수정하겠습니다) 
- 마이페이지 친구 검색 디바운싱
  - 디바운싱, 쓰로틀링 모듈 util 폴더로 분리
- API 키 값 변경된 키 값으로 타입, 변수 수정
- 공통 친구 프로필에서 친구 목록에서 사용 가능한 버튼 타입 분리 정의
- friendSlice 추가
  - followState로 친구 목록 최신 데이터로 업데이트
  - 이후 친구플래너 이동에 필요한 친구 정보 저장 활용 예상

## MR하기 전에 확인해주세요

- [x] 커밋 컨벤션을 맞췄나요?
- [ ] 오류나는 코드는 없나요?
