### PR TITLE
[FE] 토큰 만료 시 로그인 페이지로 리다이렉트, 로그인 및 회원탈퇴 시 redux 초기화

### DIFF
--- a/FE/src/App.tsx
+++ b/FE/src/App.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useState } from "react";
-import { Route, Routes, useLocation } from "react-router-dom";
+import React, { useEffect, useRef, useState } from "react";
+import { Route, Routes, useLocation, useNavigate } from "react-router-dom";
 import { createTheme, ThemeProvider } from "@mui/material/styles";
 import "./App.scss";
 import Header from "@components/common/Header";
@@ -13,11 +13,12 @@ import MyPage from "@pages/MyPage";
 import AuthPage from "@pages/AuthPage";
 import LandingPage from "@pages/LandingPage";
 import PrivateRoute from "@util/PrivateRoute";
-import { selectLoginState, setLogin } from "@store/authSlice";
+import { selectLoginState, setLogin, setLogout } from "@store/authSlice";
 import { useAppDispatch, useAppSelector } from "@hooks/hook";
 import Modal from "@components/common/Modal";
 import TokenExpiration from "@components/common/Modal/TokenExpiration";
 import { selectModal, setModalClose } from "@store/modalSlice";
+import { persistor } from "@hooks/configStore";
 
 const theme = createTheme({
   typography: {
@@ -27,9 +28,17 @@ const theme = createTheme({
 
 const App = () => {
   const dispatch = useAppDispatch();
+  const navigator = useNavigate();
   const location = useLocation();
   const [pathName, setPathName] = useState(false);
   const isLogin = useAppSelector(selectLoginState);
+  const { isOpen } = useAppSelector(selectModal);
+
+  const handleTokenExpiration = () => {
+    dispatch(setLogout());
+    persistor.purge(); // 리덕스 초기화
+    navigator("/login");
+  };
 
   useEffect(() => {
     document.documentElement.setAttribute("data-theme", "light");

--- a/FE/src/App.tsx
+++ b/FE/src/App.tsx
@@ -15,6 +15,9 @@ import LandingPage from "@pages/LandingPage";
 import PrivateRoute from "@util/PrivateRoute";
 import { selectLoginState, setLogin } from "@store/authSlice";
 import { useAppDispatch, useAppSelector } from "@hooks/hook";
+import Modal from "@components/common/Modal";
+import TokenExpiration from "@components/common/Modal/TokenExpiration";
+import { selectModal, setModalClose } from "@store/modalSlice";
 
 const theme = createTheme({
   typography: {
@@ -48,6 +51,18 @@ const App = () => {
   return (
     <ThemeProvider theme={theme}>
       {!pathName && <Header />}
+      {isLogin && (
+        <Modal
+          types="oneBtn"
+          open={isOpen}
+          onClose={() => dispatch(setModalClose())}
+          onClick={handleTokenExpiration}
+          onClickMessage="로그인 페이지로 이동"
+          prevent
+        >
+          <TokenExpiration />
+        </Modal>
+      )}
       <div id="App" style={pathName ? {} : { marginLeft: "10em" }}>
         <Routes>
           <Route element={<PrivateRoute isLogin={isLogin} option={false} />}>

--- a/FE/src/api/JsonAxios.ts
+++ b/FE/src/api/JsonAxios.ts
@@ -1,5 +1,6 @@
 import baseAxios from "axios";
 import { store } from "@hooks/configStore";
+import { setModalOpen } from "@store/modalSlice";
 
 export const baseURL = process.env.REACT_APP_API_URL;
 
@@ -26,6 +27,9 @@ Axios.interceptors.response.use(
     return res;
   },
   (err) => {
+    if (err.response.status) {
+      store.dispatch(setModalOpen());
+    }
     return Promise.reject(err);
   },
 );

--- a/FE/src/components/common/Modal/TokenExpiration.tsx
+++ b/FE/src/components/common/Modal/TokenExpiration.tsx
@@ -1,0 +1,17 @@
+import React, { useEffect, useRef } from "react";
+import styles from "@styles/common/Modal.module.scss";
+import Text from "@components/common/Text";
+import WarningAmberRoundedIcon from "@mui/icons-material/WarningAmberRounded";
+import { useNavigate } from "react-router-dom";
+
+const TokenExpiration = () => {
+  return (
+    <div className={styles["contents"]}>
+      <WarningAmberRoundedIcon />
+      <Text types="small">세션이 만료되었습니다.</Text>
+      <Text types="small">계속하려면 다시 로그인하세요.</Text>
+    </div>
+  );
+};
+
+export default TokenExpiration;

--- a/FE/src/components/common/Modal/index.tsx
+++ b/FE/src/components/common/Modal/index.tsx
@@ -8,13 +8,19 @@ interface ModalProps {
   open: boolean;
   onClose?: () => void;
   onClick?: () => void;
+  onClickMessage?: string;
+  prevent?: boolean;
   children: ReactNode;
 }
 
-const Modal = ({ types, open, onClose, onClick, children, ...rest }: ModalProps) => {
+const Modal = ({ types, open, onClose, onClick, onClickMessage, prevent, children, ...rest }: ModalProps) => {
+  const preventClose = (reason: string) => {
+    if (reason && reason === "backdropClick") return;
+  };
+
   return (
-    <MuiModal open={open} onClose={onClose} disableAutoFocus {...rest}>
-      <div className={styles["contents"]}>
+    <MuiModal open={open} onClose={prevent ? preventClose : onClose} disableAutoFocus {...rest}>
+      <div className={styles["container"]}>
         <>{children}</>
         {types != "noBtn" && (
           <div className={styles["button"]}>
@@ -24,13 +30,18 @@ const Modal = ({ types, open, onClose, onClick, children, ...rest }: ModalProps)
               </div>
             )}
             <div className={styles["button__save"]} onClick={onClick}>
-              <Text types="small">저장</Text>
+              <Text types="small">{onClickMessage}</Text>
             </div>
           </div>
         )}
       </div>
     </MuiModal>
   );
+};
+
+Modal.defaultProps = {
+  onClickMessage: "저장",
+  prevent: false,
 };
 
 export default Modal;

--- a/FE/src/components/mypage/details/myInfo/CancelMembership.tsx
+++ b/FE/src/components/mypage/details/myInfo/CancelMembership.tsx
@@ -6,6 +6,7 @@ import WarningAmberRoundedIcon from "@mui/icons-material/WarningAmberRounded";
 import { selectUserId, setLogout } from "@store/authSlice";
 import { useAppDispatch, useAppSelector } from "@hooks/hook";
 import { userApi } from "@api/Api";
+import { persistor } from "@hooks/configStore";
 
 const CancelMembership = () => {
   const dispatch = useAppDispatch();
@@ -20,6 +21,9 @@ const CancelMembership = () => {
       .then(() => {
         handleClose();
         dispatch(setLogout());
+      })
+      .then(() => {
+        persistor.purge(); // 리덕스 초기화
       })
       .catch((err) => console.error(err));
   };

--- a/FE/src/store/authSlice.ts
+++ b/FE/src/store/authSlice.ts
@@ -1,5 +1,6 @@
 import { PayloadAction, createSlice } from "@reduxjs/toolkit";
 import { rootState } from "@hooks/configStore";
+import { PURGE } from "redux-persist";
 
 export interface userInfoConfig {
   email: string;
@@ -47,6 +48,10 @@ const authSlice = createSlice({
       const [statusMessage, profileImage] = [payload.statusMessage || "", payload.profileImage || ""];
       state.userInfo = { ...payload, statusMessage, profileImage };
     },
+  },
+  extraReducers: (builder) => {
+    // redux-persist 초기화
+    builder.addCase(PURGE, () => initialState);
   },
 });
 

--- a/FE/src/store/modalSlice.ts
+++ b/FE/src/store/modalSlice.ts
@@ -14,10 +14,10 @@ const modalSlice = createSlice({
   name: "modal",
   initialState,
   reducers: {
-    setModalOpen: (state, { payload }: PayloadAction<() => void>) => {
+    setModalOpen: (state) => {
       state.isOpen = true;
     },
-    setModalClose: (state, { payload }: PayloadAction<() => void>) => {
+    setModalClose: (state) => {
       state.isOpen = false;
     },
   },

--- a/FE/src/styles/common/Modal.module.scss
+++ b/FE/src/styles/common/Modal.module.scss
@@ -2,14 +2,36 @@ $color-text: var(--color-text);
 $color-background: var(--color-background);
 $color-gray-1: var(--color-gray-1);
 $color-blue: var(--color-btn-blue);
+$color-warning: var(--color-warning);
 
-.contents {
+.container {
   position: absolute;
   top: 45%;
   left: 50%;
   transform: translate(-50%, -50%);
   width: 25em;
   background-color: $color-background;
+}
+
+.contents {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding-top: 2em;
+  color: $color-text;
+  > :nth-child(1),
+  > :nth-child(2) {
+    color: $color-warning;
+  }
+  > :nth-child(2) {
+    margin-top: 0.5em;
+    text-align: center;
+  }
+  > :nth-child(3) {
+    margin-top: 1.5em;
+    color: black;
+  }
 }
 
 .button {


### PR DESCRIPTION
close #305 

## 어떤 이유로 MR를 하셨나요?

- [ ] test 코드 작성
- [x] feature 병합
- [ ] 버그 수정
- [ ] 코드 개선
- [ ] 기타(아래에 자세한 내용 기입해주세요)

## 세부 내용 - 왜 해당 MR이 필요한지 자세하게 설명해주세요

- 공통 모달 컴포넌트에 props: prevent (배경 클릭 시 모달 꺼짐 막음), onClickMessage(onClick 버튼에 들어갈 string) 추가
- 토큰 만료 알림 모달 생성
- axios.ts에서 403 에러 & App.tsx `isLogin===true` 확인 시, 모달창 열림
- 로그아웃 및 회원탈퇴 시 리덕스 초기화 (`persistor.purge();`)

## MR하기 전에 확인해주세요

- [x] 커밋 컨벤션을 맞췄나요?
- [x] 오류나는 코드는 없나요?
