### PR TITLE
[FE] 페이지 UI 페인팅 개선

### DIFF
--- a/FE/src/App.tsx
+++ b/FE/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { Route, Routes, useLocation, useNavigate } from "react-router-dom";
 import { createTheme, ThemeProvider } from "@mui/material/styles";
 import "./App.scss";
@@ -44,7 +44,7 @@ const App = () => {
     document.documentElement.setAttribute("data-theme", "light");
   }, []);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     setPathName(["/", "/login", "/signup"].includes(location.pathname));
   }, [location.pathname]);
 

--- a/FE/src/components/auth/AuthHeader.tsx
+++ b/FE/src/components/auth/AuthHeader.tsx
@@ -1,13 +1,14 @@
 import React from "react";
 import { useNavigate } from "react-router-dom";
-import { ArrowBackIosNew, Home } from "@mui/icons-material";
+import { ArrowBackIosNew } from "@mui/icons-material";
 import Toggle from "@components/common/Header/Toggle";
 import { Box, Stack } from "@mui/material";
 
 const AuthHeader = () => {
   const navigate = useNavigate();
   const onClickBtn = () => {
-    navigate(-1);
+    if (location.pathname == "/signup") navigate("/login");
+    else navigate("/");
   };
 
   return (

--- a/FE/src/components/mypage/details/friend/MyFriend.tsx
+++ b/FE/src/components/mypage/details/friend/MyFriend.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useLayoutEffect, useState } from "react";
 import styles from "@styles/mypage/MyPage.module.scss";
 import { followerType, followingType, followRequestType } from "@util/friend.interface";
 import { useAppSelector } from "@hooks/hook";
@@ -14,7 +14,7 @@ const MyFriend = ({ title }: { title: "팔로워" | "팔로잉" | "친구검색"
   const [followingData, setFollowingData] = useState<followingType[]>([]); // 내 팔로잉
   const followState: boolean = useAppSelector(selectFollowState);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     switch (title) {
       case "팔로워":
         followApi

--- a/FE/src/components/mypage/details/friend/MyFriendFrame.tsx
+++ b/FE/src/components/mypage/details/friend/MyFriendFrame.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useLayoutEffect, useState } from "react";
 import styles from "@styles/mypage/MyPage.module.scss";
 import Text from "@components/common/Text";
 import Input from "@components/common/Input";
@@ -50,21 +50,21 @@ const MyFriendFrame = ({ title, search, friendList }: Props) => {
     return "팔로워 삭제";
   };
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!debounceKeyword.length) {
       setSearchFriend([]);
       setAlertMessage("닉네임을 통해 검색이 가능합니다.");
     }
   }, [debounceKeyword.length]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!search) {
       setSearchKeyWord("");
       setSearchFriend([]);
     }
   }, [search]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!!searchKeyWord.length)
       userApi
         .searches(userId, { nickname: searchKeyWord })

--- a/FE/src/components/social/CardList.tsx
+++ b/FE/src/components/social/CardList.tsx
@@ -98,7 +98,7 @@ const CardList = ({ sort, nickname }: { sort: "latest" | "popularity"; nickname:
       ) : (
         <>
           {list.map((social, idx) => (
-            <CardItem key={social.socialId + idx} idx={idx} item={social} handleDelete={handleDelete} />
+            <CardItem key={idx.toString() + social.socialId} idx={idx} item={social} handleDelete={handleDelete} />
           ))}
         </>
       )}

--- a/FE/src/components/social/CardList.tsx
+++ b/FE/src/components/social/CardList.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import styles from "@styles/social/Social.module.scss";
 import CardItem from "@components/social/CardItem";
 import { ProfileConfig } from "@components/common/FriendProfile";
@@ -22,7 +22,7 @@ const CardList = ({ sort, nickname }: { sort: "latest" | "popularity"; nickname:
   const obsRef = useRef(null);
 
   // 무한 스크롤
-  useEffect(() => {
+  useLayoutEffect(() => {
     preventRef.current = false;
     endRef.current = false;
     setPageNumber(1);
@@ -43,7 +43,7 @@ const CardList = ({ sort, nickname }: { sort: "latest" | "popularity"; nickname:
     }
   };
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (pageNumber != 1) getPost(pageNumber);
   }, [pageNumber]);
 

--- a/FE/src/pages/Planner/DayPage.tsx
+++ b/FE/src/pages/Planner/DayPage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useLayoutEffect, useRef, useState } from "react";
 import Header from "@components/planner/day/Header";
 import styles from "@styles/planner/day.module.scss";
 import TimeTable from "@components/planner/day/todo/TimeTable";
@@ -39,7 +39,7 @@ const DayPage = () => {
 
   const handleSuccessClose = () => setAlertSuccess(false);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const day = dayjs(date).format("YYYY-MM-DD");
     plannerApi
       .daily(friendUserId, { date: day })

--- a/FE/src/pages/Planner/MonthPage.tsx
+++ b/FE/src/pages/Planner/MonthPage.tsx
@@ -52,7 +52,6 @@ const MonthPage = () => {
     userApi
       .getProfiles(userId)
       .then((res) => {
-        console.log(userId, res.data.data);
         dispatch(setUserInfo(res.data.data));
       })
       .catch((err) => console.log(err));

--- a/FE/src/pages/Planner/MonthPage.tsx
+++ b/FE/src/pages/Planner/MonthPage.tsx
@@ -1,8 +1,8 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useLayoutEffect } from "react";
 import Month from "@components/planner/month/Month";
-import { settingApi } from "@api/Api";
+import { settingApi, userApi } from "@api/Api";
 import { useAppDispatch, useAppSelector } from "@hooks/hook";
-import { selectUserId } from "@store/authSlice";
+import { selectUserId, setUserInfo } from "@store/authSlice";
 import { setCategoryColors, setCategoryInput, setCategoryList } from "@store/mypage/categorySlice";
 import { setDdayList } from "@store/mypage/ddaySlice";
 import { CategoryItemConfig } from "@util/planner.interface";
@@ -48,7 +48,18 @@ const MonthPage = () => {
       .catch((err) => console.log(err));
   };
 
-  useEffect(() => {
+  const getProfileInfo = () => {
+    userApi
+      .getProfiles(userId)
+      .then((res) => {
+        console.log(userId, res.data.data);
+        dispatch(setUserInfo(res.data.data));
+      })
+      .catch((err) => console.log(err));
+  };
+
+  useLayoutEffect(() => {
+    getProfileInfo();
     getCategoryList();
     getCategoryColors();
     getDdayList();

--- a/FE/src/styles/common/Input.module.scss
+++ b/FE/src/styles/common/Input.module.scss
@@ -2,6 +2,7 @@ $color-border: 1px solid var(--color-gray-3);
 $color-text-placeholder: var(--color-gray-4);
 $color-text: var(--color-text);
 $color-icon: var(--color-gray-5);
+$color-background: var(--color-background);
 
 input__underline {
   border-bottom: $color-border;
@@ -20,6 +21,11 @@ input__underline {
 
     &::placeholder {
       color: $color-text-placeholder;
+    }
+
+    &:-webkit-autofill {
+      -webkit-box-shadow: 0 0 0 100px $color-background inset;
+      -webkit-text-fill-color: $color-text;
     }
   }
 


### PR DESCRIPTION
close #355 

## 어떤 이유로 MR를 하셨나요?

- [ ] test 코드 작성
- [x] feature 병합
- [x] 버그 수정
- [x] 코드 개선
- [ ] 기타(아래에 자세한 내용 기입해주세요)

## 세부 내용 - 왜 해당 MR이 필요한지 자세하게 설명해주세요

- 공통 input 자동 완성 색상 기본 배경색으로 적용
- 데이터 가져오고 페인팅 렌더링
  - 랜딩,로그인,회원가입 새로고침시 좌측 공통 헤더 깜빡임 개선
  - 일별/소셜/친구 목록 데이터 가져오고 페인팅(데이터에 의존하여 보여지는 컴포넌트 개선)
- 로그인에서 뒤로가기 누르면 랜딩 페이지로 이동
- 회원가입에서 뒤로가기 누르면 로그인 페이지로 이동
- 소셜 페이지 반복문 키 값 중복 에러 해결
- 소셜 공유 화면 캡쳐 로직 변경
  - 캡처 후 첨부된 회고 이미지가 안 보이고 textarea multiline  적용 안되는 이슈가 있음(html2Canvas 미지원 에러)
  - 회고 이미지 첨부 후 최초 1회 소셜공유시에는 함께 캡처가 잘 되지만, 2번째부터는 잘 되지 않음
  - 추후 해결 방안을 더 찾아보고, 해결할 수 없다면 html-to-image 라이브러리로 교체하는 방안 모색

## MR하기 전에 확인해주세요

- [x] 커밋 컨벤션을 맞췄나요?
- [x] 오류나는 코드는 없나요?
