### PR TITLE
[FE] 내 프로필 / 친구 프로필 이동 기능 구현

### DIFF
--- a/FE/src/components/common/FriendProfile/index.tsx
+++ b/FE/src/components/common/FriendProfile/index.tsx
@@ -7,7 +7,8 @@ import { followApi } from "@api/Api";
 import { useAppDispatch, useAppSelector } from "@hooks/hook";
 import { selectUserId } from "@store/authSlice";
 import { followType } from "@util/friend.interface";
-import { setFollowState } from "@store/friendSlice";
+import { setFollowState, setFriendInfo } from "@store/friendSlice";
+import { useNavigate } from "react-router-dom";
 
 export interface ProfileConfig {
   userId: number;
@@ -124,14 +125,21 @@ const ProfileButton = ({ profileId, types }: ProfileButtonProps) => {
 };
 
 const FriendProfile = ({ types, profile }: Props) => {
+  const dispatch = useAppDispatch();
+  const navigator = useNavigate();
   const { userId, profileImage, nickname, statusMessage } = profile;
+
+  const handleMoveToFriendProfile = () => {
+    dispatch(setFriendInfo(profile));
+    navigator("/month");
+  };
 
   return (
     <div className={styles["fprofile_container"]}>
-      <div className={styles["profile_img"]}>
+      <div className={styles["profile_img"]} onClick={handleMoveToFriendProfile}>
         <Avatar src={profileImage} />
       </div>
-      <div className={styles["fprofile_content"]}>
+      <div className={styles["fprofile_content"]} onClick={handleMoveToFriendProfile}>
         <Text types="semi-medium" bold>
           {nickname}
         </Text>

--- a/FE/src/components/common/Header/Menu.tsx
+++ b/FE/src/components/common/Header/Menu.tsx
@@ -1,8 +1,10 @@
-import React, { Children } from "react";
+import React from "react";
 import { CalendarToday, EventNote, Today, Groups } from "@mui/icons-material";
 import styles from "@styles/common/Header.module.scss";
-import Text from "../Text";
+import Text from "@components/common/Text";
 import { NavLink } from "react-router-dom";
+import { useAppDispatch } from "@hooks/hook";
+import { clearFriendInfo } from "@store/friendSlice";
 
 const values = [
   { icon: <CalendarToday />, message: "월별", link: "/month" },
@@ -12,10 +14,16 @@ const values = [
 ];
 
 const Menu = () => {
+  const dispatch = useAppDispatch();
+
+  const handleClear = () => {
+    dispatch(clearFriendInfo());
+  };
+
   return (
     <div className={styles.menu_container}>
       {values.map((item, idx) => (
-        <NavLink className={styles.menu_item} to={item.link} key={idx}>
+        <NavLink className={styles.menu_item} to={item.link} key={idx} onClick={handleClear}>
           {item.icon}
           <Text types="small">{item.message}</Text>
         </NavLink>

--- a/FE/src/components/common/Profile/index.tsx
+++ b/FE/src/components/common/Profile/index.tsx
@@ -4,6 +4,8 @@ import { ProfileConfig } from "../FriendProfile";
 import Text from "../Text";
 import Button from "../Button";
 import { Avatar } from "@mui/material";
+import { useAppDispatch } from "@hooks/hook";
+import { clearFriendInfo } from "@store/friendSlice";
 
 interface Props {
   types: "기본" | "로그아웃";
@@ -12,15 +14,20 @@ interface Props {
 }
 
 const Profile = ({ types, profile, ...rest }: Props) => {
+  const dispatch = useAppDispatch();
   const { profileImage, nickname, statusMessage } = profile;
+
+  const handleClick = () => {
+    dispatch(clearFriendInfo());
+  };
 
   return (
     <>
       <div className={styles.profile_container}>
-        <div className={styles.profile_img}>
+        <div className={styles.profile_img} onClick={handleClick}>
           <Avatar src={profileImage} sx={{ width: 80, height: 80 }} />
         </div>
-        <div className={styles.profile_content}>
+        <div className={styles.profile_content} onClick={handleClick}>
           <Text types="semi-medium" bold>
             {nickname}
           </Text>

--- a/FE/src/components/planner/month/Month.tsx
+++ b/FE/src/components/planner/month/Month.tsx
@@ -8,6 +8,7 @@ import { useAppDispatch, useAppSelector } from "@hooks/hook";
 import { selectUserId } from "@store/authSlice";
 import { MonthConfig, MonthDayConfig, setMonthInfo } from "@store/planner/monthSlice";
 import { plannerApi } from "@api/Api";
+import { selectFriendId } from "@store/friendSlice";
 
 const Month = () => {
   const dispatch = useAppDispatch();
@@ -16,6 +17,8 @@ const Month = () => {
   const year: number = dayjs(selectedDay).year();
   const month: number = dayjs(selectedDay).month() + 1;
   const userId = useAppSelector(selectUserId);
+  let friendId = useAppSelector(selectFriendId);
+  friendId = friendId != 0 ? friendId : userId;
 
   const handlePrevMonth = () => {
     const newDate = dayjs(selectedDay).subtract(1, "month").endOf("month").format("MM/DD/YY");
@@ -29,7 +32,7 @@ const Month = () => {
 
   const getMonthInfo = () => {
     plannerApi
-      .calendars(userId, { date: dayjs(new Date(year, month - 1, 1)).format("YYYY-MM-DD") })
+      .calendars(friendId, { date: dayjs(new Date(year, month - 1, 1)).format("YYYY-MM-DD") })
       .then((res) => {
         const dayList: MonthDayConfig[] = res.data.data.dayList;
         const plannerAccessScope: MonthConfig["plannerAccessScope"] = res.data.data.plannerAccessScope || "전체공개";
@@ -40,7 +43,7 @@ const Month = () => {
 
   useEffect(() => {
     getMonthInfo();
-  }, [selectedDay]);
+  }, [selectedDay, friendId]);
 
   return (
     <div className={styles["month"]}>

--- a/FE/src/components/planner/month/MonthFriends.tsx
+++ b/FE/src/components/planner/month/MonthFriends.tsx
@@ -36,9 +36,9 @@ const MonthFriends = () => {
         {followingData && followingData.length > 0 ? (
           <>
             {followingData.map((item: followingType, key: number) => {
-              const { followId, nickname, profileImage, statusMessage } = item;
+              const { followingId, nickname, profileImage, statusMessage } = item;
               const followInfo: ProfileConfig = {
-                userId: followId,
+                userId: followingId,
                 nickname,
                 statusMessage,
                 profileImage,

--- a/FE/src/components/planner/week/Week.tsx
+++ b/FE/src/components/planner/week/Week.tsx
@@ -9,16 +9,18 @@ import { useAppDispatch, useAppSelector } from "@hooks/hook";
 import { DayListConfig, selectDayList, setThisWeek, setWeekInfo } from "@store/planner/weekSlice";
 import { selectUserId, selectUserInfo } from "@store/authSlice";
 import { plannerApi } from "@api/Api";
-import { selectFriendInfo } from "@store/friendSlice";
+import { selectFriendId, selectFriendInfo } from "@store/friendSlice";
 
 const Week = () => {
   const dispatch = useAppDispatch();
   const userId = useAppSelector(selectUserId);
+  let friendId = useAppSelector(selectFriendId);
+  friendId = friendId != 0 ? friendId : userId;
   const friendInfo = useAppSelector(selectFriendInfo);
   const dayList = useAppSelector(selectDayList);
   const [week, setWeek] = useState(new Date());
   const thisWeekCnt = getThisWeekCnt(week);
-  const [isMine, setIsMine] = useState<boolean>(true);
+  const [isMine, setIsMine] = useState<boolean>(friendId === userId);
 
   const handleButton = (to: string) => {
     const date = week.getDate();
@@ -33,7 +35,7 @@ const Week = () => {
   const getDayList = () => {
     const dates = getThisWeek(week);
     plannerApi
-      .weekly(userId, { "start-date": dates[0], "end-date": dates[1] })
+      .weekly(friendId, { "start-date": dates[0], "end-date": dates[1] })
       .then((res) => {
         const response = res.data.data;
         dispatch(
@@ -51,7 +53,8 @@ const Week = () => {
 
   useEffect(() => {
     getDayList();
-  }, [week]);
+    if (friendId === userId) setIsMine(true);
+  }, [week, friendId]);
 
   return (
     <div className={styles["week"]}>

--- a/FE/src/pages/Planner/DayPage.tsx
+++ b/FE/src/pages/Planner/DayPage.tsx
@@ -15,11 +15,13 @@ import { ref, uploadBytes, getDownloadURL } from "firebase/storage";
 import { firebaseStorage } from "@api/firebaseConfig";
 import html2canvas from "html2canvas";
 import Alert from "@components/common/Alert";
+import { selectFriendId } from "@store/friendSlice";
 
 const DayPage = () => {
   const dispatch = useAppDispatch();
   const userId = useAppSelector(selectUserId);
-  const friendUserId = userId;
+  let friendUserId = useAppSelector(selectFriendId);
+  friendUserId = friendUserId != 0 ? friendUserId : userId;
   const date = useAppSelector(selectDate);
   const todoList = useAppSelector(selectTodoList);
   const [ment, setMent] = useState({
@@ -64,7 +66,7 @@ const DayPage = () => {
         setTotalTime({ studyTimeHour: response.studyTimeHour, studyTimeMinute: response.studyTimeMinute });
       })
       .catch((err) => console.error(err));
-  }, [date]);
+  }, [date, friendUserId]);
 
   useEffect(() => {
     const sumMinute = todoList

--- a/FE/src/store/friendSlice.ts
+++ b/FE/src/store/friendSlice.ts
@@ -34,11 +34,15 @@ const friendSlice = createSlice({
     setFollowState: (state, { payload }: PayloadAction<friendConfig["followState"]>) => {
       state.followState = payload;
     },
+    clearFriendInfo: (state) => {
+      state.friendInfo = initialState.friendInfo;
+    },
   },
 });
 
-export const { setFriendDate, setFriendInfo, setFollowState } = friendSlice.actions;
+export const { setFriendDate, setFriendInfo, setFollowState, clearFriendInfo } = friendSlice.actions;
 export const selectFriendDate = (state: rootState) => state.friend.friendDate;
 export const selectFriendInfo = (state: rootState) => state.friend.friendInfo;
+export const selectFriendId = (state: rootState) => state.friend.friendInfo.userId;
 export const selectFollowState = (state: rootState) => state.friend.followState;
 export default friendSlice.reducer;


### PR DESCRIPTION
close #337

## 어떤 이유로 MR를 하셨나요?

- [ ] test 코드 작성
- [x] feature 병합
- [ ] 버그 수정
- [ ] 코드 개선
- [ ] 기타(아래에 자세한 내용 기입해주세요)

## 세부 내용 - 왜 해당 MR이 필요한지 자세하게 설명해주세요

- 친구 프로필 클릭 시 friendInfo 데이터 들어감.
- friendSlice에 friendInfo 초기화 action 생성.
네비게이션, 내 프로필 클릭 시 friendInfo 초기화.
- 친구 프로필 클릭 시 친구 캘린더로 이동, 캘린더에서 일 클릭 시 친구 일별 플래너 보임, 주별 보기 클릭 시 친구 주별 플래너 보임.

## MR하기 전에 확인해주세요

- [x] 커밋 컨벤션을 맞췄나요?
- [x] 오류나는 코드는 없나요?
