### PR TITLE
[FE] 구글 로그인 시 사용자 정보 저장 및 비밀번호 변경 탭 삭제

### DIFF
--- a/FE/src/App.tsx
+++ b/FE/src/App.tsx
@@ -35,6 +35,7 @@ const App = () => {
   const { isOpen } = useAppSelector(selectModal);
 
   const handleTokenExpiration = () => {
+    dispatch(setModalClose());
     dispatch(setLogout());
     persistor.purge(); // 리덕스 초기화
     navigator("/login");

--- a/FE/src/components/auth/login/Login.tsx
+++ b/FE/src/components/auth/login/Login.tsx
@@ -78,10 +78,16 @@ const Login = () => {
     const token = getCookie("token");
     const id = getCookie("userId");
     if (token && id) {
-      dispatch(setLogin({ accessToken: token, userId: parseInt(id) }));
-      deleteCookie("token");
-      deleteCookie("userId");
-      navigator("/month");
+      userApi
+        .getProfiles(parseInt(id))
+        .then((res) => {
+          dispatch(setLogin({ accessToken: token, userId: parseInt(id) }));
+          dispatch(setUserInfo(res.data.data));
+          deleteCookie("token");
+          deleteCookie("userId");
+          navigator("/month");
+        })
+        .catch((err) => console.log(err));
     }
   }, [document.cookie]);
 

--- a/FE/src/components/auth/login/Login.tsx
+++ b/FE/src/components/auth/login/Login.tsx
@@ -7,7 +7,7 @@ import Google from "@assets/Icons/google_icon.svg";
 import { NavLink, useNavigate } from "react-router-dom";
 import { authApi, userApi } from "@api/Api";
 import { useAppDispatch } from "@hooks/hook";
-import { setLogin, setUserInfo } from "@store/authSlice";
+import { setIsGoogle, setLogin, setUserInfo } from "@store/authSlice";
 
 const getCookie = (name: string) => {
   var value = document.cookie.match("(^|;) ?" + name + "=([^;]*)(;|$)");
@@ -83,11 +83,12 @@ const Login = () => {
         .then((res) => {
           dispatch(setLogin({ accessToken: token, userId: parseInt(id) }));
           dispatch(setUserInfo(res.data.data));
-          deleteCookie("token");
-          deleteCookie("userId");
+          dispatch(setIsGoogle(true));
           navigator("/month");
         })
         .catch((err) => console.log(err));
+      deleteCookie("token");
+      deleteCookie("userId");
     }
   }, [document.cookie]);
 

--- a/FE/src/components/auth/login/Login.tsx
+++ b/FE/src/components/auth/login/Login.tsx
@@ -34,7 +34,7 @@ const Login = () => {
   const { email, password } = loginInfo;
 
   const handleGoogleLogin = () => {
-    window.location.href = "https://shadowmate.kro.kr/api/oauth/google";
+    window.location.href = process.env.REACT_APP_API_URL + "/api/oauth/google";
   };
 
   const onChange = (e: ChangeEvent<HTMLInputElement>) => {

--- a/FE/src/components/mypage/MyPageTab.tsx
+++ b/FE/src/components/mypage/MyPageTab.tsx
@@ -1,13 +1,14 @@
 import React, { Dispatch, SetStateAction, useEffect, useRef, useState } from "react";
 import styles from "@styles/mypage/MyPage.module.scss";
 import Text from "@components/common/Text";
+import { useAppSelector } from "@hooks/hook";
+import { selectIsGoogle } from "@store/authSlice";
 
 interface MyPageTabProps {
   setTabName: Dispatch<SetStateAction<string>>;
 }
 
 interface TabListType {
-  id: string;
   title: string;
   contents: {
     index: number;
@@ -16,18 +17,24 @@ interface TabListType {
 }
 
 const TAB_LIST: TabListType[] = [
-  { id: "info", title: "내 정보", contents: { index: 0, list: ["내 정보 확인", "비밀번호 변경", "회원탈퇴"] } },
   {
-    id: "diary",
+    title: "내 정보",
+    contents: {
+      index: 0,
+      list: ["내 정보 확인", "비밀번호 변경", "회원탈퇴"],
+    },
+  },
+  {
     title: "다이어리",
     contents: { index: 1, list: ["다이어리 설정", "카테고리 설정", "디데이 설정"] },
   },
-  { id: "friend", title: "친구", contents: { index: 2, list: ["팔로워 목록", "팔로잉 목록", "친구 검색"] } },
+  { title: "친구", contents: { index: 2, list: ["팔로워 목록", "팔로잉 목록", "친구 검색"] } },
 ];
 
 const MyPageTab = ({ setTabName }: MyPageTabProps) => {
   const [headerIndex, setHeaderIndex] = useState<number>(0); // 상위 카테고리
   const [subIndex, setSubIndex] = useState<string>("내 정보 확인"); // 하위 카테고리
+  const isGoogle = useAppSelector(selectIsGoogle);
 
   const handleLink = (list: string, idx: number) => {
     setHeaderIndex(idx);
@@ -41,14 +48,18 @@ const MyPageTab = ({ setTabName }: MyPageTabProps) => {
         const clicked = idx === headerIndex ? "--clicked" : "";
         return (
           <div key={idx} className={styles[`tab__title${clicked}`]}>
-            <input type="checkbox" id={item.id} checked readOnly />
-            <label htmlFor={item.id}>{item.title}</label>
+            <input type="checkbox" id={item.title} checked readOnly />
+            <label htmlFor={item.title}>{item.title}</label>
             {item.contents.list && (
               <div className={styles["tab__contents"]}>
                 {item.contents.list.map((list, idx) => {
                   const cur = item.contents.index;
                   return (
-                    <div onClick={() => handleLink(list, cur)} key={idx}>
+                    <div
+                      onClick={() => handleLink(list, cur)}
+                      key={idx}
+                      style={{ display: isGoogle && list === "비밀번호 변경" ? "none" : "visible" }}
+                    >
                       <Text types="small" bold={list === subIndex}>
                         {list}
                       </Text>

--- a/FE/src/store/authSlice.ts
+++ b/FE/src/store/authSlice.ts
@@ -14,6 +14,7 @@ interface authConfig {
   accessToken: string;
   userId: number;
   login: boolean;
+  isGoogle: boolean;
   userInfo: userInfoConfig;
 }
 
@@ -21,6 +22,7 @@ const initialState: authConfig = {
   accessToken: "",
   userId: 0,
   login: false,
+  isGoogle: false,
   userInfo: {
     email: "",
     nickname: "",
@@ -39,6 +41,9 @@ const authSlice = createSlice({
       state.login = true;
       state.userId = payload.userId;
     },
+    setIsGoogle: (state, { payload }: PayloadAction<boolean>) => {
+      state.isGoogle = payload;
+    },
     setLogout: (state) => {
       state = initialState;
       localStorage.removeItem("accessToken");
@@ -55,9 +60,11 @@ const authSlice = createSlice({
   },
 });
 
-export const { setLogin, setLogout, setUserInfo } = authSlice.actions;
+export const { setLogin, setLogout, setUserInfo, setIsGoogle } = authSlice.actions;
 export const selectUserInfo = (state: rootState) => state.auth.userInfo;
 export const selectLoginState = (state: rootState) => state.auth.login;
 export const selectAccessToken = (state: rootState) => state.auth.accessToken;
 export const selectUserId = (state: rootState) => state.auth.userId;
+export const selectIsGoogle = (state: rootState) => state.auth.isGoogle;
+
 export default authSlice.reducer;


### PR DESCRIPTION
close #360 

## 어떤 이유로 MR를 하셨나요?

- [ ] test 코드 작성
- [ ] feature 병합
- [x] 버그 수정
- [x] 코드 개선
- [ ] 기타(아래에 자세한 내용 기입해주세요)

## 세부 내용 - 왜 해당 MR이 필요한지 자세하게 설명해주세요

- 구글 로그인 주소 .env 환경변수 값으로 변경
- 구글 로그인 후 authSlice에 유저 정보 저장
- authSlice에 구글 로그인 여부(boolean) 생성 및 로그인 시 저장
- 구글 로그인인 경우, 마이페이지 - 비밀번호 변경 탭 `display:"none"` 설정
- 토큰 만료 후 로그인 시 모달 안 없어지는 에러 수정

## MR하기 전에 확인해주세요

- [x] 커밋 컨벤션을 맞췄나요?
- [x] 오류나는 코드는 없나요?
