### PR TITLE
[FE] 다른 사용자가 보는 일별 플래너

### DIFF
--- a/FE/src/components/common/FriendProfile/index.tsx
+++ b/FE/src/components/common/FriendProfile/index.tsx
@@ -37,7 +37,9 @@ const ProfileButton = ({ profileId, types, nickname }: ProfileButtonProps) => {
     if (state != 0) dispatch(setFollowState(state));
     if (types == "기본") {
       userApi.searches(userId, { nickname }).then((res) => {
+        console.log("type", type, res.data.data.isFollow);
         if (res.data.data.isFollow == "EMPTY") setType("아이콘");
+        else setType("기본");
       });
     }
   }, [state]);

--- a/FE/src/components/common/FriendProfile/index.tsx
+++ b/FE/src/components/common/FriendProfile/index.tsx
@@ -3,7 +3,7 @@ import styles from "@styles/common/Profile.module.scss";
 import Text from "@components/common/Text";
 import PersonAddIcon from "@mui/icons-material/PersonAdd";
 import { Avatar } from "@mui/material";
-import { followApi } from "@api/Api";
+import { followApi, userApi } from "@api/Api";
 import { useAppDispatch, useAppSelector } from "@hooks/hook";
 import { selectUserId } from "@store/authSlice";
 import { followType } from "@util/friend.interface";
@@ -24,15 +24,22 @@ interface Props {
 
 interface ProfileButtonProps extends Omit<Props, "profile"> {
   profileId: number;
+  nickname: string;
 }
 
-const ProfileButton = ({ profileId, types }: ProfileButtonProps) => {
+const ProfileButton = ({ profileId, types, nickname }: ProfileButtonProps) => {
   const dispatch = useAppDispatch();
   const userId = useAppSelector(selectUserId);
   const [state, setState] = useState(0);
+  const [type, setType] = useState(types);
 
   useEffect(() => {
     if (state != 0) dispatch(setFollowState(state));
+    if (types == "기본") {
+      userApi.searches(userId, { nickname }).then((res) => {
+        if (res.data.data.isFollow == "EMPTY") setType("아이콘");
+      });
+    }
   }, [state]);
 
   const handleClick = (() => {
@@ -121,7 +128,7 @@ const ProfileButton = ({ profileId, types }: ProfileButtonProps) => {
         <PersonAddIcon />
       </div>
     ),
-  }[types];
+  }[type];
 };
 
 const FriendProfile = ({ types, profile }: Props) => {
@@ -145,7 +152,9 @@ const FriendProfile = ({ types, profile }: Props) => {
         </Text>
         <Text types="default">{statusMessage}</Text>
       </div>
-      <div className={styles["fprofile_button"]}>{<ProfileButton profileId={userId} types={types} />}</div>
+      <div className={styles["fprofile_button"]}>
+        {<ProfileButton types={types} profileId={userId} nickname={nickname} />}
+      </div>
     </div>
   );
 };

--- a/FE/src/components/planner/day/Header.tsx
+++ b/FE/src/components/planner/day/Header.tsx
@@ -8,14 +8,15 @@ import FriendProfile from "@components/common/FriendProfile";
 import { NavigateBefore, NavigateNext } from "@mui/icons-material";
 import { useAppDispatch, useAppSelector } from "@hooks/hook";
 import { setDate, selectDate, selectDayInfo } from "@store/planner/daySlice";
-import { todoData_friend } from "@util/data/DayTodos";
 import dayjs from "dayjs";
 import "dayjs/locale/ko";
 import { selectFriendInfo } from "@store/friendSlice";
+import { selectUserId } from "@store/authSlice";
 dayjs.locale("ko");
 
 const FriendHeader = () => {
   const navigate = useNavigate();
+  const userId = useAppSelector(selectUserId);
   const { likeCount, like } = useAppSelector(selectDayInfo);
   const [heartNum, setHeartNum] = useState(likeCount);
   const [isHeartClick, setIsHeartClick] = useState(like);
@@ -43,7 +44,7 @@ const FriendHeader = () => {
           주간보기
         </Button>
       </div>
-      <FriendProfile types={"아이콘"} profile={friendInfo} />
+      <FriendProfile types={"기본"} profile={friendInfo} />
     </div>
   );
 };

--- a/FE/src/components/planner/day/Header.tsx
+++ b/FE/src/components/planner/day/Header.tsx
@@ -11,6 +11,7 @@ import { setDate, selectDate, selectDayInfo } from "@store/planner/daySlice";
 import { todoData_friend } from "@util/data/DayTodos";
 import dayjs from "dayjs";
 import "dayjs/locale/ko";
+import { selectFriendInfo } from "@store/friendSlice";
 dayjs.locale("ko");
 
 const FriendHeader = () => {
@@ -18,6 +19,7 @@ const FriendHeader = () => {
   const { likeCount, like } = useAppSelector(selectDayInfo);
   const [heartNum, setHeartNum] = useState(likeCount);
   const [isHeartClick, setIsHeartClick] = useState(like);
+  const friendInfo = useAppSelector(selectFriendInfo);
 
   function heartClick() {
     setIsHeartClick(!isHeartClick);
@@ -41,7 +43,7 @@ const FriendHeader = () => {
           주간보기
         </Button>
       </div>
-      <FriendProfile types={"아이콘"} profile={todoData_friend} />
+      <FriendProfile types={"아이콘"} profile={friendInfo} />
     </div>
   );
 };

--- a/FE/src/components/planner/week/Week.tsx
+++ b/FE/src/components/planner/week/Week.tsx
@@ -81,7 +81,7 @@ const Week = () => {
         </div>
         {!isMine && (
           <div>
-            <FriendProfile types="아이콘" profile={friendInfo} />
+            <FriendProfile types="기본" profile={friendInfo} />
           </div>
         )}
       </div>

--- a/FE/src/components/social/CardItem.tsx
+++ b/FE/src/components/social/CardItem.tsx
@@ -19,29 +19,29 @@ const SocialProfile = ({ idx, item, handleDelete }: Props) => {
   const navigator = useNavigate();
   const dispatch = useAppDispatch();
   const userName = useAppSelector(selectUserInfo).nickname;
-  const { socialId, socialImage, dailyPlannerDay, ...user } = item;
-  const mine = user.nickname == userName;
-  const { profileImage, statusMessage, nickname } = user;
+  const { socialId, socialImage, dailyPlannerDay, ...friend } = item;
+  const mine = userName == friend.nickname;
+  const { profileImage, statusMessage, nickname } = friend;
 
   const handleClickProfile = () => {
-    dispatch(setFriendInfo(user));
+    dispatch(setFriendInfo(friend));
     navigator("/month");
   };
 
   return (
-    <div className={styles["social-profile__container"]} onClick={handleClickProfile}>
-      <div className={styles["social-profile__img"]}>
+    <div className={styles["social-profile__container"]}>
+      <div className={styles["social-profile__img"]} onClick={handleClickProfile}>
         <Avatar src={profileImage} />
       </div>
-      <div className={styles["social-profile__content"]}>
+      <div className={styles["social-profile__content"]} onClick={handleClickProfile}>
         <Text types="semi-medium" bold>
           {nickname}
         </Text>
         <Text types="default">{statusMessage}</Text>
       </div>
-      <div className={styles["social-profile__button"]}>
+      <div className={styles["social-profile__button"]} onClick={(e) => handleDelete(e, idx, socialId)}>
         {mine && (
-          <div onClick={(e) => handleDelete(e, idx, socialId)}>
+          <div>
             <DeleteOutline />
           </div>
         )}

--- a/FE/src/components/social/CardItem.tsx
+++ b/FE/src/components/social/CardItem.tsx
@@ -8,6 +8,7 @@ import { useAppDispatch, useAppSelector } from "@hooks/hook";
 import { selectUserInfo } from "@store/authSlice";
 import { useNavigate } from "react-router-dom";
 import { setFriendDate, setFriendInfo } from "@store/friendSlice";
+import { setDate } from "@store/planner/daySlice";
 
 interface Props {
   item: SocialListType;
@@ -56,7 +57,7 @@ const CardItem = ({ idx, item, handleDelete }: Props) => {
   const { socialId, socialImage, dailyPlannerDay, ...user } = item;
 
   const handleClickImage = () => {
-    dispatch(setFriendDate(dailyPlannerDay));
+    dispatch(setDate(dailyPlannerDay));
     dispatch(setFriendInfo(user));
     navigator("/day");
   };

--- a/FE/src/components/social/CardList.tsx
+++ b/FE/src/components/social/CardList.tsx
@@ -80,7 +80,6 @@ const CardList = ({ sort, nickname }: { sort: "latest" | "popularity"; nickname:
 
   // 내 공유 플래너 삭제
   const handleDelete = (e: React.MouseEvent<HTMLDivElement, MouseEvent>, idx: number, socialId: number) => {
-    e.stopPropagation();
     socialApi
       .delete(userId, socialId)
       .then(() => {


### PR DESCRIPTION
close #362

## 어떤 이유로 MR를 하셨나요?

- [ ] test 코드 작성
- [x] feature 병합
- [ ] 버그 수정
- [ ] 코드 개선
- [ ] 기타(아래에 자세한 내용 기입해주세요)

## 세부 내용 - 왜 해당 MR이 필요한지 자세하게 설명해주세요

- 다른 사용자가 보는 일별, 주별 친구 프로필 헤더
  - 방문한 플래너가 나와 팔로잉 상태가 아니라면 친구 추가 버튼 보이기
- 소셜 페이지에서 다른 사용자 플래너 이동
  - 소셜이미지 클릭시 해당 플래너 사용자 공유한 일자별 플래너로 이동
  - 프로필 클릭 해당 사용자 월별 플래너로 이동

## MR하기 전에 확인해주세요

- [x] 커밋 컨벤션을 맞췄나요?
- [x] 오류나는 코드는 없나요?
