### PR TITLE
[FE] 일별 플래너 일부 수정

### DIFF
--- a/FE/src/components/common/Dday/index.tsx
+++ b/FE/src/components/common/Dday/index.tsx
@@ -1,7 +1,10 @@
-import React from "react";
+import React, { useEffect } from "react";
 import Text from "@components/common/Text";
 import colors from "@util/colors";
 import dayjs from "dayjs";
+import { useAppSelector } from "@hooks/hook";
+import { selectUserId } from "@store/authSlice";
+import { selectFriendId } from "@store/friendSlice";
 
 interface Props {
   nearDate: string | number | Date | dayjs.Dayjs;
@@ -9,7 +12,10 @@ interface Props {
 }
 
 const Dday = ({ nearDate, comparedDate }: Props) => {
-  const isVisible = nearDate !== null;
+  const userId = useAppSelector(selectUserId);
+  let friendId = useAppSelector(selectFriendId);
+  friendId = friendId != 0 ? friendId : userId;
+  const isVisible = nearDate !== null && userId == friendId;
 
   const dday = (() => {
     if (isVisible) {

--- a/FE/src/components/common/Header/Menu.tsx
+++ b/FE/src/components/common/Header/Menu.tsx
@@ -5,6 +5,8 @@ import Text from "@components/common/Text";
 import { NavLink } from "react-router-dom";
 import { useAppDispatch } from "@hooks/hook";
 import { clearFriendInfo } from "@store/friendSlice";
+import dayjs from "dayjs";
+import { setDayDate } from "@store/planner/daySlice";
 
 const values = [
   { icon: <CalendarToday />, message: "월별", link: "/month" },
@@ -16,14 +18,15 @@ const values = [
 const Menu = () => {
   const dispatch = useAppDispatch();
 
-  const handleClear = () => {
+  const handleClear = (link: string) => {
+    if (link == "/day") dispatch(setDayDate(dayjs().format("YYYY-MM-DD")));
     dispatch(clearFriendInfo());
   };
 
   return (
     <div className={styles.menu_container}>
       {values.map((item, idx) => (
-        <NavLink className={styles.menu_item} to={item.link} key={idx} onClick={handleClear}>
+        <NavLink className={styles.menu_item} to={item.link} key={idx} onClick={() => handleClear(item.link)}>
           {item.icon}
           <Text types="small">{item.message}</Text>
         </NavLink>

--- a/FE/src/components/common/Header/index.tsx
+++ b/FE/src/components/common/Header/index.tsx
@@ -4,16 +4,19 @@ import Toggle from "./Toggle";
 import Menu from "./Menu";
 import { Avatar } from "@mui/material";
 import { NavLink } from "react-router-dom";
-import { useAppSelector } from "@hooks/hook";
+import { useAppDispatch, useAppSelector } from "@hooks/hook";
 import { selectUserInfo } from "@store/authSlice";
+import { clearFriendInfo } from "@store/friendSlice";
 
 const Header = () => {
+  const dispatch = useAppDispatch();
+  const handleClear = () => dispatch(clearFriendInfo());
   const profileImage = useAppSelector(selectUserInfo).profileImage;
 
   return (
     <div className={styles.header_container}>
       <NavLink to="/month">
-        <div className={styles.header_logo}>
+        <div className={styles.header_logo} onClick={handleClear}>
           <span>Shadow</span>
           <br />
           <span>Mate</span>

--- a/FE/src/components/planner/day/Header.tsx
+++ b/FE/src/components/planner/day/Header.tsx
@@ -7,7 +7,7 @@ import Button from "@components/common/Button";
 import FriendProfile from "@components/common/FriendProfile";
 import { NavigateBefore, NavigateNext } from "@mui/icons-material";
 import { useAppDispatch, useAppSelector } from "@hooks/hook";
-import { setDayDate, selectDayDate, selectDayInfo, setDayLike } from "@store/planner/daySlice";
+import { setDayDate, selectDayDate, selectDayInfo, setDayLike, setDayInfo } from "@store/planner/daySlice";
 import dayjs from "dayjs";
 import "dayjs/locale/ko";
 import { selectFriendInfo } from "@store/friendSlice";
@@ -60,14 +60,15 @@ const FriendHeader = () => {
 };
 
 const MyHeader = ({ socialClick }: { socialClick: () => Promise<void> }) => {
-  const { plannerAccessScope, likeCount, shareSocial, dailyTodos } = useAppSelector(selectDayInfo);
-  const [isSocialClick, setIsSocialClick] = useState(shareSocial);
+  const dispatch = useAppDispatch();
+  const dayPlannerInfo = useAppSelector(selectDayInfo);
+  const { plannerAccessScope, likeCount, shareSocial, dailyTodos } = dayPlannerInfo;
 
   function handleClick() {
-    if (!isSocialClick) {
+    if (!shareSocial) {
+      dispatch(setDayInfo({ ...dayPlannerInfo, shareSocial: true }));
       socialClick();
-      setIsSocialClick(!isSocialClick);
-    }
+    } else dispatch(setDayInfo({ ...dayPlannerInfo, shareSocial: false }));
   }
 
   return (
@@ -76,7 +77,7 @@ const MyHeader = ({ socialClick }: { socialClick: () => Promise<void> }) => {
         ♥ {likeCount}
       </Button>
       {plannerAccessScope == "전체공개" && (
-        <div className={`${isSocialClick ? styles["button__visit"] : ""}`}>
+        <div className={`${shareSocial ? styles["button__visit"] : ""}`}>
           <Button types="blue" onClick={() => handleClick()} disabled={!dailyTodos.length}>
             소셜공유
           </Button>

--- a/FE/src/components/planner/day/Header.tsx
+++ b/FE/src/components/planner/day/Header.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import styles from "@styles/planner/day.module.scss";
 import Text from "@components/common/Text";
@@ -7,7 +7,7 @@ import Button from "@components/common/Button";
 import FriendProfile from "@components/common/FriendProfile";
 import { NavigateBefore, NavigateNext } from "@mui/icons-material";
 import { useAppDispatch, useAppSelector } from "@hooks/hook";
-import { setDate, selectDayDate, selectDayInfo, setDayLike } from "@store/planner/daySlice";
+import { setDayDate, selectDayDate, selectDayInfo, setDayLike } from "@store/planner/daySlice";
 import dayjs from "dayjs";
 import "dayjs/locale/ko";
 import { selectFriendInfo } from "@store/friendSlice";
@@ -101,7 +101,7 @@ const Header = ({ isFriend, socialClick }: Props) => {
 
   const moveDate = (n: -1 | 0 | 1) => {
     const newDate = n == 0 ? dayjs().format("YYYY-MM-DD") : dayjs(date).add(n, "day").format("YYYY-MM-DD");
-    dispatch(setDate(newDate));
+    dispatch(setDayDate(newDate));
   };
 
   return (

--- a/FE/src/components/planner/day/Header.tsx
+++ b/FE/src/components/planner/day/Header.tsx
@@ -98,8 +98,8 @@ const Header = ({ isFriend, socialClick }: Props) => {
   const titleDay = dayjs(date).format("YYYY년 M월 DD일 ddd요일");
 
   const moveDate = (n: -1 | 0 | 1) => {
-    const newDate = dayjs(date).add(n, "day").format("YYYY-MM-DD");
-    dispatch(setDayDate(newDate));
+    const newDate = n == 0 ? dayjs() : dayjs(date).add(n, "day");
+    dispatch(setDayDate(newDate.format("YYYY-MM-DD")));
   };
 
   return (

--- a/FE/src/components/planner/day/Header.tsx
+++ b/FE/src/components/planner/day/Header.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import styles from "@styles/planner/day.module.scss";
 import Text from "@components/common/Text";
@@ -60,16 +60,14 @@ const FriendHeader = () => {
 };
 
 const MyHeader = ({ socialClick }: { socialClick: () => Promise<void> }) => {
-  const plannerAccessScope = useAppSelector(selectDayInfo).plannerAccessScope;
-  const shareSocial = useAppSelector(selectDayInfo).shareSocial;
+  const { plannerAccessScope, likeCount, shareSocial, dailyTodos } = useAppSelector(selectDayInfo);
   const [isSocialClick, setIsSocialClick] = useState(shareSocial);
-  const { likeCount } = useAppSelector(selectDayInfo);
 
   function handleClick() {
     if (!isSocialClick) {
       socialClick();
+      setIsSocialClick(!isSocialClick);
     }
-    setIsSocialClick(!isSocialClick);
   }
 
   return (
@@ -79,7 +77,7 @@ const MyHeader = ({ socialClick }: { socialClick: () => Promise<void> }) => {
       </Button>
       {plannerAccessScope == "전체공개" && (
         <div className={`${isSocialClick ? styles["button__visit"] : ""}`}>
-          <Button types="blue" onClick={() => handleClick()}>
+          <Button types="blue" onClick={() => handleClick()} disabled={!dailyTodos.length}>
             소셜공유
           </Button>
         </div>

--- a/FE/src/components/planner/day/Header.tsx
+++ b/FE/src/components/planner/day/Header.tsx
@@ -51,7 +51,7 @@ const FriendHeader = () => {
           </Button>
         </div>
         <Button types="gray" onClick={() => weekClick()}>
-          주간보기
+          주별보기
         </Button>
       </div>
       <FriendProfile types={"기본"} profile={friendInfo} />

--- a/FE/src/components/planner/day/Header.tsx
+++ b/FE/src/components/planner/day/Header.tsx
@@ -100,7 +100,7 @@ const Header = ({ isFriend, socialClick }: Props) => {
   const titleDay = dayjs(date).format("YYYY년 M월 DD일 ddd요일");
 
   const moveDate = (n: -1 | 0 | 1) => {
-    const newDate = n == 0 ? dayjs().format("YYYY-MM-DD") : dayjs(date).add(n, "day").format("YYYY-MM-DD");
+    const newDate = dayjs(date).add(n, "day").format("YYYY-MM-DD");
     dispatch(setDayDate(newDate));
   };
 

--- a/FE/src/components/planner/day/todo/TodoItem.tsx
+++ b/FE/src/components/planner/day/todo/TodoItem.tsx
@@ -7,6 +7,9 @@ import { AddOutlined, DeleteOutlined } from "@mui/icons-material";
 import { BASIC_CATEGORY_ITEM } from "@store/planner/daySlice";
 import { TodoConfig } from "@util/planner.interface";
 import { CategoryItemConfig } from "@util/planner.interface";
+import { useAppSelector } from "@hooks/hook";
+import { selectUserId } from "@store/authSlice";
+import { selectFriendId } from "@store/friendSlice";
 
 interface Props {
   idx?: number;
@@ -21,6 +24,8 @@ interface Props {
 }
 
 const TodoItem = ({ idx = -1, todoItem, addTodo, disable, todoModule }: Props) => {
+  const userId = useAppSelector(selectUserId);
+  const friendId = useAppSelector(selectFriendId);
   const { todoContent, todoStatus } = todoItem;
   const category = (() => todoItem.category || BASIC_CATEGORY_ITEM)();
   const { categoryTitle, categoryColorCode } = category;
@@ -130,7 +135,7 @@ const TodoItem = ({ idx = -1, todoItem, addTodo, disable, todoModule }: Props) =
           <div className={styles["todo-item__content__possible"]}>
             <input
               value={text}
-              placeholder={"할 일을 입력하세요"}
+              placeholder={userId == friendId ? "할 일을 입력하세요" : ""}
               minLength={2}
               maxLength={maxLength}
               onChange={editText}

--- a/FE/src/components/planner/day/todo/TodoItem.tsx
+++ b/FE/src/components/planner/day/todo/TodoItem.tsx
@@ -7,9 +7,6 @@ import { AddOutlined, DeleteOutlined } from "@mui/icons-material";
 import { BASIC_CATEGORY_ITEM } from "@store/planner/daySlice";
 import { TodoConfig } from "@util/planner.interface";
 import { CategoryItemConfig } from "@util/planner.interface";
-import { useAppSelector } from "@hooks/hook";
-import { selectUserId } from "@store/authSlice";
-import { selectFriendId } from "@store/friendSlice";
 
 interface Props {
   idx?: number;
@@ -24,9 +21,6 @@ interface Props {
 }
 
 const TodoItem = ({ idx = -1, todoItem, addTodo, disable, todoModule }: Props) => {
-  const userId = useAppSelector(selectUserId);
-  let friendId = useAppSelector(selectFriendId);
-  friendId = friendId != 0 ? friendId : userId;
   const { todoContent, todoStatus } = todoItem;
   const category = (() => todoItem.category || BASIC_CATEGORY_ITEM)();
   const { categoryTitle, categoryColorCode } = category;
@@ -136,7 +130,7 @@ const TodoItem = ({ idx = -1, todoItem, addTodo, disable, todoModule }: Props) =
           <div className={styles["todo-item__content__possible"]}>
             <input
               value={text}
-              placeholder={userId == friendId ? "할 일을 입력하세요" : ""}
+              placeholder={"할 일을 입력하세요"}
               minLength={2}
               maxLength={maxLength}
               onChange={editText}

--- a/FE/src/components/planner/day/todo/TodoItem.tsx
+++ b/FE/src/components/planner/day/todo/TodoItem.tsx
@@ -25,7 +25,8 @@ interface Props {
 
 const TodoItem = ({ idx = -1, todoItem, addTodo, disable, todoModule }: Props) => {
   const userId = useAppSelector(selectUserId);
-  const friendId = useAppSelector(selectFriendId);
+  let friendId = useAppSelector(selectFriendId);
+  friendId = friendId != 0 ? friendId : userId;
   const { todoContent, todoStatus } = todoItem;
   const category = (() => todoItem.category || BASIC_CATEGORY_ITEM)();
   const { categoryTitle, categoryColorCode } = category;

--- a/FE/src/components/planner/day/todo/TodoItemChoice.tsx
+++ b/FE/src/components/planner/day/todo/TodoItemChoice.tsx
@@ -9,9 +9,10 @@ interface Props {
   idx?: number;
   todoItem: TodoConfig;
   possible: boolean;
+  disable?: boolean;
 }
 
-const TodoItemChoice = ({ todoItem, possible }: Props) => {
+const TodoItemChoice = ({ todoItem, possible, disable }: Props) => {
   const dispatch = useAppDispatch();
   const { todoContent, todoStatus } = todoItem;
   const category = (() => todoItem.category || BASIC_CATEGORY_ITEM)();
@@ -41,7 +42,10 @@ const TodoItemChoice = ({ todoItem, possible }: Props) => {
   }
 
   return (
-    <div className={`${styles["todo-item"]} ${styles[possibility]}`} onClick={handleClickTodo}>
+    <div
+      className={`${styles[`todo-item${disable ? "--disable" : ""}`]} ${styles[possibility]}`}
+      onClick={handleClickTodo}
+    >
       <div className={styles["todo-item__category"]}>
         <div className={styles["todo-item__category-box"]} style={categoryStyle(categoryColorCode)}>
           <Text>{categoryTitle}</Text>

--- a/FE/src/components/planner/day/todo/TodoList.tsx
+++ b/FE/src/components/planner/day/todo/TodoList.tsx
@@ -7,6 +7,7 @@ import { TodoConfig } from "@util/planner.interface";
 import TodoItemChoice from "./TodoItemChoice";
 import { plannerApi } from "@api/Api";
 import { selectUserId } from "@store/authSlice";
+import { selectFriendId } from "@store/friendSlice";
 
 interface Props {
   clicked: boolean;
@@ -15,6 +16,8 @@ interface Props {
 const TodoList = ({ clicked }: Props) => {
   const dispatch = useAppDispatch();
   const userId = useAppSelector(selectUserId);
+  let friendId = useAppSelector(selectFriendId);
+  friendId = friendId != 0 ? friendId : userId;
   const date = useAppSelector(selectDayDate);
   const todoArr = useAppSelector(selectTodoList);
   const listSize = 11;
@@ -90,7 +93,7 @@ const TodoList = ({ clicked }: Props) => {
           {todoArr.map((item: TodoConfig, idx: number) => (
             <TodoItem key={item.todoId} idx={idx} todoItem={item} todoModule={todoModule} />
           ))}
-          <TodoItem addTodo todoItem={BASIC_TODO_ITEM} todoModule={todoModule} />
+          <TodoItem addTodo todoItem={BASIC_TODO_ITEM} todoModule={todoModule} disable={userId != friendId} />
           {Array.from({ length: listSize - todoArr.length - 1 }).map((_, idx) => (
             <TodoItem key={idx} disable todoItem={BASIC_TODO_ITEM} todoModule={todoModule} />
           ))}

--- a/FE/src/components/planner/day/todo/TodoList.tsx
+++ b/FE/src/components/planner/day/todo/TodoList.tsx
@@ -106,7 +106,7 @@ const TodoList = ({ clicked }: Props) => {
             />
           ))}
           {Array.from({ length: listSize - todoArr.length }).map((_, idx) => (
-            <TodoItemChoice key={idx} todoItem={BASIC_TODO_ITEM} possible={false} />
+            <TodoItemChoice key={idx} todoItem={BASIC_TODO_ITEM} possible={false} disable />
           ))}
         </>
       )}

--- a/FE/src/components/planner/month/MonthCalendar.tsx
+++ b/FE/src/components/planner/month/MonthCalendar.tsx
@@ -6,7 +6,7 @@ import CheckRoundedIcon from "@mui/icons-material/CheckRounded";
 import { useAppDispatch, useAppSelector } from "@hooks/hook";
 import { useNavigate } from "react-router-dom";
 import { MonthDayConfig, selectMonthDayList } from "@store/planner/monthSlice";
-import { setDate } from "@store/planner/daySlice";
+import { setDayDate } from "@store/planner/daySlice";
 import Loading from "@components/common/Loading";
 
 interface Props {
@@ -35,7 +35,7 @@ const MonthCalendar = ({ selectedDay }: Props) => {
   };
 
   const itemClickHandler = (date: string) => {
-    dispatch(setDate(date));
+    dispatch(setDayDate(date));
     navigate("/day");
   };
 

--- a/FE/src/components/social/CardItem.tsx
+++ b/FE/src/components/social/CardItem.tsx
@@ -8,7 +8,7 @@ import { useAppDispatch, useAppSelector } from "@hooks/hook";
 import { selectUserInfo } from "@store/authSlice";
 import { useNavigate } from "react-router-dom";
 import { setFriendInfo } from "@store/friendSlice";
-import { setDate } from "@store/planner/daySlice";
+import { setDayDate } from "@store/planner/daySlice";
 
 interface Props {
   item: SocialListType;
@@ -58,7 +58,7 @@ const CardItem = ({ idx, item, handleDelete }: Props) => {
   const [isLoading, setIsLoading] = useState(true);
 
   const handleClickImage = () => {
-    dispatch(setDate(dailyPlannerDay));
+    dispatch(setDayDate(dailyPlannerDay));
     dispatch(setFriendInfo(user));
     navigator("/day");
   };

--- a/FE/src/pages/Planner/DayPage.tsx
+++ b/FE/src/pages/Planner/DayPage.tsx
@@ -14,7 +14,6 @@ import { selectUserId } from "@store/authSlice";
 import { ref, uploadString, getDownloadURL } from "firebase/storage";
 import { firebaseStorage } from "@api/firebaseConfig";
 import html2canvas from "html2canvas";
-import Alert from "@components/common/Alert";
 import { selectFriendId } from "@store/friendSlice";
 
 const DayPage = () => {
@@ -35,11 +34,8 @@ const DayPage = () => {
     studyTimeHour: 0,
     studyTimeMinute: 0,
   });
-  const [alertSuccess, setAlertSuccess] = useState<boolean>(false);
   const todoDivRef = useRef<HTMLDivElement>(null);
   const screenDivRef = useRef<HTMLDivElement>(null);
-
-  const handleSuccessClose = () => setAlertSuccess(false);
 
   useLayoutEffect(() => {
     const day = dayjs(date).format("YYYY-MM-DD");
@@ -139,7 +135,6 @@ const DayPage = () => {
           plannerApi.social(userId, { date, socialImage: downloadURL }).catch((err) => console.error(err)),
         ),
       );
-      setAlertSuccess(true);
     });
   };
 

--- a/FE/src/store/planner/daySlice.ts
+++ b/FE/src/store/planner/daySlice.ts
@@ -54,7 +54,7 @@ const daySlice = createSlice({
   name: "plannerDay",
   initialState,
   reducers: {
-    setDate: (state, action: PayloadAction<dayConfig["date"]>) => {
+    setDayDate: (state, action: PayloadAction<dayConfig["date"]>) => {
       state.date = action.payload;
     },
     setDayInfo: (state, action: PayloadAction<dayConfig["info"]>) => {
@@ -88,7 +88,7 @@ const daySlice = createSlice({
 
 export const BASIC_TODO_ITEM = initialState.todoItem!;
 export const BASIC_CATEGORY_ITEM = initialState.todoItem.category!;
-export const { setDate, setDayInfo, setDayLike, setTodoItem, setTodoList, setTimeTable } = daySlice.actions;
+export const { setDayDate, setDayInfo, setDayLike, setTodoItem, setTodoList, setTimeTable } = daySlice.actions;
 export const selectDayDate = (state: rootState) => state.day.date;
 export const selectDayInfo = (state: rootState) => state.day.info;
 export const selectTodoItem = (state: rootState) => state.day.todoItem;

--- a/FE/src/styles/common/Profile.module.scss
+++ b/FE/src/styles/common/Profile.module.scss
@@ -3,6 +3,7 @@ $color-gray_1: var(--color-gray-1);
 $color-gray_3: var(--color-gray-3);
 $color-blue: var(--color-btn-blue);
 $color-white: var(--color-white);
+$color-text: var(--color-text);
 
 .profile_container,
 .fprofile_container {
@@ -77,6 +78,7 @@ $color-white: var(--color-white);
     border: none;
     border-radius: 0.625rem;
     background-color: $color-background;
+    color: $color-text;
     cursor: pointer;
   }
   > div {

--- a/FE/src/styles/planner/Week.module.scss
+++ b/FE/src/styles/planner/Week.module.scss
@@ -46,7 +46,7 @@ $border: 1px;
 
     // 친구 프로필 영역
     > div:nth-child(2) {
-      width: 20em;
+      width: 22.5vw;
       margin: 0.5em;
     }
   }

--- a/FE/src/styles/planner/day.module.scss
+++ b/FE/src/styles/planner/day.module.scss
@@ -101,7 +101,7 @@ $color-btn-blue: var(--color-btn-blue);
   @extend %item-container;
   height: 5em;
   display: grid;
-  grid-template-columns: max-content auto;
+  grid-template-columns: 2fr 1fr;
   align-items: end;
   border-bottom: solid 1px $color-gray_4;
 
@@ -128,7 +128,7 @@ $color-btn-blue: var(--color-btn-blue);
   }
 
   button {
-    width: 6rem;
+    width: 5rem;
   }
 
   .button__visit > button {
@@ -152,11 +152,15 @@ $color-btn-blue: var(--color-btn-blue);
   }
 
   &__friend {
+    width: 100%;
     height: 100%;
-    display: grid;
+    overflow: hidden;
+    display: flex;
     justify-items: end;
-    grid-template-columns: 1fr 1fr;
+    justify-content: flex-end;
     gap: 0.5em;
+    padding-left: 0.5em;
+    box-sizing: border-box;
 
     > div:nth-child(1) {
       height: 100%;
@@ -170,7 +174,7 @@ $color-btn-blue: var(--color-btn-blue);
     }
 
     > div:nth-child(2) {
-      width: 100%;
+      width: 22.5vw;
     }
   }
 }

--- a/FE/src/styles/planner/day.module.scss
+++ b/FE/src/styles/planner/day.module.scss
@@ -278,6 +278,7 @@ $color-btn-blue: var(--color-btn-blue);
   width: 100%;
   display: grid;
   grid-template-columns: 7rem auto 2rem;
+  grid-template-rows: 1fr;
   border-bottom: 1px solid $color-text;
   position: relative;
 


### PR DESCRIPTION
close #380 

## 어떤 이유로 MR를 하셨나요?

- [ ] test 코드 작성
- [x] feature 병합
- [ ] 버그 수정
- [ ] 코드 개선
- [ ] 기타(아래에 자세한 내용 기입해주세요)

## 세부 내용 - 왜 해당 MR이 필요한지 자세하게 설명해주세요

- 헤더 메뉴에서 일별 클릭시, 오늘 날짜로 이동하기
- 헤더 로고 클릭시 친구 정보 초기화
- 일별 플래너 할 일 등록 1개 이상일 때만 소셜 공유 버튼 활성화
- 다른 사용자가 보는 일별 플래너
  - "할 일을 입력하세요" placeholder 감추기
  - Dday 감추기
  - 친구 프로필 width 고정 길이 변경(주별 플래너 style에도 길이 적용)
- 친구 프로필 버튼 테마 색상 적용
  
## MR하기 전에 확인해주세요

- [x] 커밋 컨벤션을 맞췄나요?
- [x] 오류나는 코드는 없나요?
