### PR TITLE
[FE] 주별 플래너 헤더 수정 및 일별 이동 기능 구현

### DIFF
--- a/FE/src/components/planner/day/Header.tsx
+++ b/FE/src/components/planner/day/Header.tsx
@@ -13,6 +13,8 @@ import "dayjs/locale/ko";
 import { selectFriendInfo } from "@store/friendSlice";
 import { plannerApi } from "@api/Api";
 import { selectUserId } from "@store/authSlice";
+import { setThisWeek } from "@store/planner/weekSlice";
+import { getThisWeek } from "@util/getThisWeek";
 dayjs.locale("ko");
 
 const FriendHeader = () => {
@@ -39,6 +41,7 @@ const FriendHeader = () => {
   }
 
   function weekClick() {
+    dispatch(setThisWeek(dayjs(getThisWeek(date)[0]).toDate()));
     navigate("/week");
   }
 

--- a/FE/src/components/planner/week/Week.tsx
+++ b/FE/src/components/planner/week/Week.tsx
@@ -98,7 +98,14 @@ const Week = () => {
         <div className={styles["week__list"]}>
           <WeekTodo isMine={isMine} />
           {dayList?.map((today: DayListConfig, key: number) => (
-            <WeekList key={key} idx={key} isMine={isMine} retroClick={retroClick} setRetroClick={setRetroClick} />
+            <WeekList
+              key={key}
+              idx={key}
+              isMine={isMine}
+              today={today}
+              retroClick={retroClick}
+              setRetroClick={setRetroClick}
+            />
           ))}
         </div>
       )}

--- a/FE/src/components/planner/week/Week.tsx
+++ b/FE/src/components/planner/week/Week.tsx
@@ -5,6 +5,7 @@ import WeekTodo from "@components/planner/week/todo/WeekTodo";
 import Text from "@components/common/Text";
 import Loading from "@components/common/Loading";
 import FriendProfile from "@components/common/FriendProfile";
+import { NavigateBefore, NavigateNext } from "@mui/icons-material";
 import { getThisWeek, getThisWeekCnt } from "@util/getThisWeek";
 import { useAppDispatch, useAppSelector } from "@hooks/hook";
 import { DayListConfig, selectDayList, selectThisWeek, setThisWeek, setWeekInfo } from "@store/planner/weekSlice";
@@ -72,20 +73,16 @@ const Week = () => {
           </Text>
           <div>
             <div className={styles["week__button"]} onClick={() => handleButton("forward")}>
-              <svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" fillRule="evenodd" clipRule="evenodd">
-                <path d="M20 .755l-14.374 11.245 14.374 11.219-.619.781-15.381-12 15.391-12 .609.755z" />
-              </svg>
+              <NavigateBefore />
             </div>
             <div
               className={styles["week__today"]}
               onClick={() => dispatch(setThisWeek(dayjs(getThisWeek(new Date())[0]).toDate()))}
             >
-              <Text>TODAY</Text>
+              <Text bold>today</Text>
             </div>
             <div className={styles["week__button"]} onClick={() => handleButton("backward")}>
-              <svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" fillRule="evenodd" clipRule="evenodd">
-                <path d="M4 .755l14.374 11.245-14.374 11.219.619.781 15.381-12-15.391-12-.609.755z" />
-              </svg>
+              <NavigateNext />
             </div>
           </div>
         </div>

--- a/FE/src/components/planner/week/list/WeekList.tsx
+++ b/FE/src/components/planner/week/list/WeekList.tsx
@@ -7,7 +7,9 @@ import WeekItemInput from "@components/planner/week/list/WeekItemInput";
 import { dateFormat } from "@util/getThisWeek";
 import { TodoConfig } from "@util/planner.interface";
 import { useAppDispatch, useAppSelector } from "@hooks/hook";
+import { useNavigate } from "react-router-dom";
 import { DayListConfig, selectDayList, selectWeekDday, setDayList } from "@store/planner/weekSlice";
+import { setDayDate } from "@store/planner/daySlice";
 import { plannerApi } from "@api/Api";
 import { selectUserId } from "@store/authSlice";
 import dayjs from "dayjs";
@@ -15,12 +17,14 @@ import dayjs from "dayjs";
 interface Props {
   idx: number;
   isMine: boolean;
+  today: DayListConfig;
   retroClick: number;
   setRetroClick: Dispatch<SetStateAction<number>>;
 }
 
-const WeekList = ({ idx, isMine, retroClick, setRetroClick }: Props) => {
+const WeekList = ({ idx, isMine, today, retroClick, setRetroClick }: Props) => {
   const dispatch = useAppDispatch();
+  const navigator = useNavigate();
   const userId = useAppSelector(selectUserId);
   const nearDate = useAppSelector(selectWeekDday);
   const dayList: DayListConfig[] = useAppSelector(selectDayList);
@@ -47,6 +51,11 @@ const WeekList = ({ idx, isMine, retroClick, setRetroClick }: Props) => {
       .catch((err) => console.log(err));
   };
 
+  const handleMoveToDay = () => {
+    dispatch(setDayDate(today.date));
+    navigator("/day");
+  };
+
   useEffect(() => {
     setDailyTodos(dayList[idx].dailyTodos || []);
     setRetrospection(dayList[idx].retrospection || "");
@@ -55,7 +64,9 @@ const WeekList = ({ idx, isMine, retroClick, setRetroClick }: Props) => {
   return (
     <div className={styles["item"]}>
       <div className={styles["item__title"]}>
-        <Text>{dateFormat(date)}</Text>
+        <div onClick={handleMoveToDay}>
+          <Text>{dateFormat(date)}</Text>
+        </div>
         <Dday nearDate={nearDate} comparedDate={dateFormat(date)} />
       </div>
       <div className={styles["item__todo-list"]} style={{ gridTemplateRows: `repeat(${rowMaxLength}, 20%` }}>

--- a/FE/src/styles/planner/Week.module.scss
+++ b/FE/src/styles/planner/Week.module.scss
@@ -35,8 +35,7 @@ $border: 1px;
       align-items: end;
 
       > span:nth-child(1) {
-        width: 19rem;
-        padding-left: 1em;
+        width: 15rem;
         box-sizing: border-box;
       }
 

--- a/FE/src/styles/planner/Week.module.scss
+++ b/FE/src/styles/planner/Week.module.scss
@@ -2,6 +2,7 @@
 $color-text: var(--color-text);
 $color-white: var(--color-white);
 $color-black: var(--color-black);
+$color-gray-1: var(--color-gray-1);
 $color-gray-4: var(--color-gray-4);
 $color-gray-5: var(--color-gray-5);
 $border: 1px;
@@ -169,6 +170,13 @@ $border: 1px;
     display: flex;
     justify-content: center;
     align-items: center;
+    > div:nth-child(1):hover {
+      padding: 0.2em 0.5em;
+      box-sizing: border-box;
+      border-radius: 0.625rem;
+      background-color: $color-gray-1;
+      cursor: pointer;
+    }
     > span {
       // DDay
       &:nth-child(2) {

--- a/FE/src/styles/planner/Week.module.scss
+++ b/FE/src/styles/planner/Week.module.scss
@@ -1,3 +1,4 @@
+@use "@styles/common/Text.module.scss";
 $color-text: var(--color-text);
 $color-white: var(--color-white);
 $color-black: var(--color-black);
@@ -22,38 +23,40 @@ $border: 1px;
   // 타이틀 전체 영역
   &__title {
     @extend %under_boder, %flex_row;
-    height: 4.5em;
+    height: 5em;
     justify-content: space-between;
-    align-items: center;
+    padding: 0.5em 0.5rem;
+    box-sizing: border-box;
 
     // 타이틀 + 좌우 버튼
     > div:nth-child(1) {
       @extend %flex_row;
-      align-items: center;
-      margin-left: 1em;
+      align-items: end;
 
       > span:nth-child(1) {
-        min-width: 8em;
+        width: 19rem;
+        padding-left: 1em;
+        box-sizing: border-box;
       }
 
       // 좌우 버튼
       > div:nth-child(2) {
         @extend %flex_row;
+        @extend .text-semi-large;
         align-items: center;
-        margin-left: 1em;
+        gap: 0.3em;
       }
     }
 
     // 친구 프로필 영역
     > div:nth-child(2) {
+      align-self: center;
       width: 22.5vw;
-      margin: 0.5em;
     }
   }
 
   &__button,
   &__today {
-    margin-right: 1em;
     fill: $color-text;
     cursor: pointer;
   }
@@ -62,7 +65,7 @@ $border: 1px;
   &__list {
     @extend %flex_row;
     flex-wrap: wrap;
-    height: calc(100% - 4.5em - $border); // ( 전체높이 - 타이틀 높이 - border 높이 )
+    height: calc(100% - 5em - $border); // ( 전체높이 - 타이틀 높이 - border 높이 )
   }
 }
 


### PR DESCRIPTION
close #438 

## 어떤 이유로 MR를 하셨나요?

- [ ] test 코드 작성
- [x] feature 병합
- [ ] 버그 수정
- [ ] 코드 개선
- [ ] 기타(아래에 자세한 내용 기입해주세요)

## 세부 내용 - 왜 해당 MR이 필요한지 자세하게 설명해주세요

- 주별 플래너 일별 플래너와 헤더 디자인 통일
- 주별 플래너에서 일별 플래너로 이동하는 버튼 (일자 클릭) 생성 및 이동 구현
- 친구의 일별 플래너에서 주별 플래너로 이동 시 주차 반영 (해당 일자가 포함된 주차의 플래너로 이동)

## MR하기 전에 확인해주세요

- [x] 커밋 컨벤션을 맞췄나요?
- [x] 오류나는 코드는 없나요?
