### PR TITLE
[FE] 마이페이지 에러 및 CSS 수정

### DIFF
--- a/FE/src/components/common/Profile/index.tsx
+++ b/FE/src/components/common/Profile/index.tsx
@@ -7,7 +7,7 @@ import Avatar from "@components/common/Avatar";
 import { persistor } from "@hooks/configStore";
 import { useAppDispatch, useAppSelector } from "@hooks/hook";
 import { selectUserId, setLogout } from "@store/authSlice";
-import { selectFriendId } from "@store/friendSlice";
+import { clearFriendInfo, selectFriendId } from "@store/friendSlice";
 import SettingsIcon from "@mui/icons-material/Settings";
 
 interface Props {
@@ -24,6 +24,7 @@ const Profile = ({ types, profile }: Props) => {
 
   const handleLogout = () => {
     dispatch(setLogout());
+    dispatch(clearFriendInfo());
     setTimeout(() => {
       persistor.purge();
     }, 200);

--- a/FE/src/components/mypage/details/diary/Category.tsx
+++ b/FE/src/components/mypage/details/diary/Category.tsx
@@ -3,6 +3,8 @@ import styles from "@styles/mypage/MyPage.module.scss";
 import Text from "@components/common/Text";
 import Input from "@components/common/Input";
 import CategoryColorList from "@components/mypage/item/CategoryColorList";
+import AppleIcon from "@mui/icons-material/Apple";
+import MicrosoftIcon from "@mui/icons-material/Microsoft";
 import { CategoryColorConfig, CategoryItemConfig } from "@util/planner.interface";
 import { useAppDispatch, useAppSelector } from "@hooks/hook";
 import {
@@ -74,14 +76,31 @@ const MyPageCategory = () => {
           value={categoryEmoticon || ""}
           placeholder="카테고리 이모지"
           onChange={onChangeInput}
-          helperText={
-            // <>
-            //   윈도우 사용 시 윈도우키 + . 를 눌러보세요.
-            //   <br /> 맥 사용 시 Fn + E 를 눌러보세요.
-            // </>
-            <>이모지 외 사용이 불가능합니다.</>
-          }
+          helperText={"이모지 외 사용이 불가능합니다."}
         />
+      </div>
+      <div className={styles["frame__line"]}>
+        <div /> {/* 타이틀 빈공간 대체 */}
+        <div className={styles["emoji__info"]}>
+          <span>
+            <MicrosoftIcon />
+            <span>
+              <Text types="small" bold>
+                Window&nbsp;&nbsp;&nbsp;
+              </Text>
+              <Text types="small">Window + .</Text>
+            </span>
+          </span>
+          <span>
+            <AppleIcon />
+            <span>
+              <Text types="small" bold>
+                MacOS&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+              </Text>
+              <Text types="small">Control + Command + SpaceBar</Text>
+            </span>
+          </span>
+        </div>
       </div>
       <div className={styles["frame__line"]}>
         <Text>카테고리 색상</Text>

--- a/FE/src/components/mypage/details/diary/Category.tsx
+++ b/FE/src/components/mypage/details/diary/Category.tsx
@@ -37,7 +37,7 @@ const MyPageCategory = () => {
     }
     if (name === "categoryTitle") {
       setLength(value.length);
-      if (value.length < 2 || value.length >= 10) {
+      if (value.length < 2 || value.length > 10) {
         setError(true);
       } else setError(false);
     }

--- a/FE/src/components/mypage/details/diary/Dday.tsx
+++ b/FE/src/components/mypage/details/diary/Dday.tsx
@@ -27,7 +27,7 @@ const MyPageDday = () => {
     const { value, name } = e.target;
     if (name === "ddayTitle") {
       setLength(value.length);
-      if (value.length < 2 || value.length >= 20) {
+      if (value.length < 2 || value.length > 20) {
         setError(true);
       } else setError(false);
     }

--- a/FE/src/components/mypage/details/diary/Diary.tsx
+++ b/FE/src/components/mypage/details/diary/Diary.tsx
@@ -86,7 +86,7 @@ const MyPageDiary = () => {
           <Text types="small">
             <>전체 공개 및 친구 공개 상태에서 비공개 전환 시,</>
             <br />
-            <>소셜에 공유된 게시글이 삭제됩니다.</>
+            <>소셜에 공유된 게시글이 숨김 처리됩니다.</>
           </Text>
           <Text types="small">계속 진행하시겠습니까?</Text>
         </div>

--- a/FE/src/components/mypage/details/diary/Diary.tsx
+++ b/FE/src/components/mypage/details/diary/Diary.tsx
@@ -7,9 +7,9 @@ import SaveIcon from "@mui/icons-material/Save";
 import Modal from "@components/common/Modal";
 import WarningAmberRoundedIcon from "@mui/icons-material/WarningAmberRounded";
 import { useAppDispatch, useAppSelector } from "@hooks/hook";
-import { selectUserId } from "@store/authSlice";
-import { MonthConfig, selectPlannerAccessScope, setPlannerAccessScope } from "@store/planner/monthSlice";
-import { settingApi } from "@api/Api";
+import { selectPlannerAccessScope, selectUserId, setUserInfo } from "@store/authSlice";
+import { MonthConfig, setPlannerAccessScope } from "@store/planner/monthSlice";
+import { settingApi, userApi } from "@api/Api";
 
 const MyPageDiary = () => {
   const dispatch = useAppDispatch();
@@ -26,6 +26,10 @@ const MyPageDiary = () => {
       .then(() => {
         dispatch(setPlannerAccessScope(scope));
         handleClose();
+        userApi
+          .getProfiles(userId)
+          .then((res) => dispatch(setUserInfo(res.data.data)))
+          .catch((err) => console.log(err));
       })
       .catch((err) => console.log(err));
   };

--- a/FE/src/store/authSlice.ts
+++ b/FE/src/store/authSlice.ts
@@ -66,5 +66,6 @@ export const selectLoginState = (state: rootState) => state.auth.login;
 export const selectAccessToken = (state: rootState) => state.auth.accessToken;
 export const selectUserId = (state: rootState) => state.auth.userId;
 export const selectIsGoogle = (state: rootState) => state.auth.isGoogle;
+export const selectPlannerAccessScope = (state: rootState) => state.auth.userInfo.plannerAccessScope;
 
 export default authSlice.reducer;

--- a/FE/src/store/mypage/categorySlice.ts
+++ b/FE/src/store/mypage/categorySlice.ts
@@ -2,7 +2,7 @@ import React from "react";
 import { rootState } from "@hooks/configStore";
 import { PayloadAction, createSlice } from "@reduxjs/toolkit";
 import { CategoryColorConfig, CategoryItemConfig } from "@util/planner.interface";
-import CategoryList from "@components/mypage/list/CategoryList";
+import { PURGE } from "redux-persist";
 
 interface CategoryConfig {
   categoryList: CategoryItemConfig[];
@@ -44,6 +44,10 @@ const categorySlice = createSlice({
     setCategoryColorClick: (state, { payload }: PayloadAction<number>) => {
       state.categoryColorClick = payload;
     },
+  },
+  extraReducers: (builder) => {
+    // redux-persist 초기화
+    builder.addCase(PURGE, () => initialState);
   },
 });
 

--- a/FE/src/store/mypage/ddaySlice.ts
+++ b/FE/src/store/mypage/ddaySlice.ts
@@ -2,6 +2,7 @@ import React from "react";
 import { rootState } from "@hooks/configStore";
 import { PayloadAction, createSlice } from "@reduxjs/toolkit";
 import { DdayItemConfig } from "@util/planner.interface";
+import { PURGE } from "redux-persist";
 
 interface DdayConfig {
   ddayList: DdayItemConfig[];
@@ -32,6 +33,10 @@ const ddaySlice = createSlice({
     setDdayInput: (state, { payload }: PayloadAction<DdayItemConfig>) => {
       state.ddayInput = payload;
     },
+  },
+  extraReducers: (builder) => {
+    // redux-persist 초기화
+    builder.addCase(PURGE, () => initialState);
   },
 });
 

--- a/FE/src/store/planner/monthSlice.ts
+++ b/FE/src/store/planner/monthSlice.ts
@@ -36,6 +36,5 @@ const monthSlice = createSlice({
 
 export const { setMonthInfo, setPlannerAccessScope } = monthSlice.actions;
 export const selectMonthDayList = (state: rootState) => state.month.dayList;
-export const selectPlannerAccessScope = (state: rootState) => state.month.plannerAccessScope;
 
 export default monthSlice.reducer;

--- a/FE/src/styles/mypage/MyPage.module.scss
+++ b/FE/src/styles/mypage/MyPage.module.scss
@@ -260,6 +260,23 @@ $color-warning: var(--color-warning);
   }
 }
 
+.emoji__info {
+  display: flex;
+  flex-direction: column;
+  background-color: $color-gray-1;
+  margin-top: -1.5em;
+  padding: 1em;
+  gap: 0.2em;
+  > span {
+    display: flex;
+    justify-items: center;
+    gap: 0.2em;
+    > svg {
+      font-size: medium;
+    }
+  }
+}
+
 .color {
   &__container {
     width: 100%;
@@ -283,13 +300,6 @@ $color-warning: var(--color-warning);
       outline-offset: 2px;
     }
   }
-}
-
-.emoji {
-  position: absolute;
-  bottom: 90;
-  height: 22em;
-  z-index: 100;
 }
 
 .dday {

--- a/FE/src/styles/mypage/MyPage.module.scss
+++ b/FE/src/styles/mypage/MyPage.module.scss
@@ -35,6 +35,8 @@ $color-warning: var(--color-warning);
   grid-template-columns: 3.5fr 7.5fr;
   gap: 1em;
   height: 100%;
+  padding: 0 1em;
+  box-sizing: border-box;
 
   &__container {
     position: relative;


### PR DESCRIPTION
close #441 

## 어떤 이유로 MR를 하셨나요?

- [ ] test 코드 작성
- [ ] feature 병합
- [x] 버그 수정
- [ ] 코드 개선
- [x] 기타(아래에 자세한 내용 기입해주세요)

## 세부 내용 - 왜 해당 MR이 필요한지 자세하게 설명해주세요

- 마이페이지 CSS 수정:
카테고리/디데이 padding 수정해서 내 정보, 다이어리 페이지와 규격 맞춤
카테고리 이모지 단축키 안내문 추가

- 마이페이지 에러 수정:
카테고리 디데이 persist에 저장된 정보 로그아웃 시 초기화될 수 있도록 PURGE 추가
로그아웃 시 friendInfo 초기화, 이전 방문한 친구 내역 남아있지 않게 함.
다이어리 공개 여부 변경 시 "삭제" -> "숨김 처리"로 문구 변경
다이어리 공개 여부 변경 시 다시 프로필 조회하여, 바로 정보 갱신할 수 있도록 함.
카테고리, 디데이 허용 글자수 1개씩 모자라는 에러 수정



## MR하기 전에 확인해주세요

- [x] 커밋 컨벤션을 맞췄나요?
- [x] 오류나는 코드는 없나요?
