### PR TITLE
[FE] 이미지 확장자 제한 및 이미지 리사이징 업로드

### DIFF
--- a/FE/src/components/mypage/details/myInfo/MyInfo.tsx
+++ b/FE/src/components/mypage/details/myInfo/MyInfo.tsx
@@ -174,7 +174,7 @@ const MyPageInfo = () => {
         title: "프로필 사진",
         node: (
           <div className={styles["info__profile-img"]}>
-            <input type="file" id="imageFile" accept="image/*" onChange={renderImage} />
+            <input type="file" id="imageFile" accept="image/jpeg, image/png" onChange={renderImage} />
             <label htmlFor="imageFile">
               <Avatar src={profileImage} />
             </label>

--- a/FE/src/components/mypage/details/myInfo/MyInfo.tsx
+++ b/FE/src/components/mypage/details/myInfo/MyInfo.tsx
@@ -8,6 +8,7 @@ import Button from "@components/common/Button";
 import { selectUserId, selectUserInfo, setUserInfo, userInfoConfig } from "@store/authSlice";
 import { ref, uploadBytes, getDownloadURL } from "firebase/storage";
 import { firebaseStorage } from "@api/firebaseConfig";
+import { resizeImage } from "@util/resizeImage";
 import { useAppDispatch, useAppSelector } from "@hooks/hook";
 import { authApi, userApi } from "@api/Api";
 import { userRegex } from "@util/regex";
@@ -107,7 +108,7 @@ const MyPageInfo = () => {
     } else {
       let newProfileImage = profileImage;
       if (saveImageFile != null) {
-        const file = saveImageFile;
+        const file = await resizeImage(saveImageFile);
         const storageRef = ref(firebaseStorage, `profile/${userId}`);
         await uploadBytes(storageRef, file).then((snapshot) =>
           getDownloadURL(snapshot.ref).then((downloadURL) => (newProfileImage = downloadURL)),

--- a/FE/src/components/planner/day/Ment.tsx
+++ b/FE/src/components/planner/day/Ment.tsx
@@ -5,6 +5,7 @@ import { IconButton } from "@mui/material";
 import Text from "@components/common/Text";
 import { firebaseStorage } from "@api/firebaseConfig";
 import { ref, uploadBytes, getDownloadURL } from "firebase/storage";
+import { resizeImage } from "@util/resizeImage";
 import { plannerApi } from "@api/Api";
 import { useAppSelector } from "@hooks/hook";
 import { selectUserId } from "@store/authSlice";
@@ -43,12 +44,11 @@ const FileImg = ({ retrospectionImage, setRetrospectionImage }: fileImgProps) =>
 
     const reader = new FileReader();
     reader.readAsDataURL(e.target.files[0]);
-    reader.onloadend = () => {
+    reader.onloadend = async () => {
       setRetrospectionImage(reader.result as string);
       if (e.target.files != null) {
-        const file = e.target.files[0];
+        const file = await resizeImage(e.target.files[0]);
         const storageRef = ref(firebaseStorage, `retrospections/${userId + "_" + date}`);
-
         uploadBytes(storageRef, file).then((snapshot) =>
           getDownloadURL(snapshot.ref).then((downloadURL) => {
             saveImage(downloadURL);

--- a/FE/src/components/planner/day/Ment.tsx
+++ b/FE/src/components/planner/day/Ment.tsx
@@ -65,7 +65,7 @@ const FileImg = ({ retrospectionImage, setRetrospectionImage }: fileImgProps) =>
 
   return (
     <div className={styles["ment-preview__box"]}>
-      <input type="file" id="imageFile" accept="image/*" onChange={renderImage} />
+      <input type="file" id="imageFile" accept="image/jpeg, image/png" onChange={renderImage} />
       {retrospectionImage ? (
         <div className={styles["ment-preview__img"]}>
           <img src={retrospectionImage} alt="img-preview" />

--- a/FE/src/pages/Planner/DayPage.tsx
+++ b/FE/src/pages/Planner/DayPage.tsx
@@ -11,7 +11,7 @@ import dayjs from "dayjs";
 import { TodoConfig } from "@util/planner.interface";
 import { plannerApi } from "@api/Api";
 import { selectUserId } from "@store/authSlice";
-import { ref, uploadString, getDownloadURL } from "firebase/storage";
+import { ref, uploadBytes, getDownloadURL } from "firebase/storage";
 import { firebaseStorage } from "@api/firebaseConfig";
 import html2canvas from "html2canvas";
 import { selectFriendId } from "@store/friendSlice";
@@ -139,20 +139,23 @@ const DayPage = () => {
 
   const handleDownload = async () => {
     if (!screenDivRef.current) return;
-    await html2canvas(screenDivRef.current, {
+    const canvas = await html2canvas(screenDivRef.current, {
       windowWidth: 1200,
       windowHeight: 682,
       logging: false,
       allowTaint: true,
       useCORS: true,
-    }).then(async (canvas) => {
-      const imageURL = canvas.toDataURL("image/png");
-      const storageRef = ref(firebaseStorage, `social/${userId + "_" + date}`);
-      uploadString(storageRef, imageURL, "data_url").then((snapshot) =>
-        getDownloadURL(snapshot.ref).then((downloadURL) =>
-          plannerApi.social(userId, { date, socialImage: downloadURL }).catch((err) => console.error(err)),
-        ),
-      );
+    });
+    canvas.toBlob(async (blob) => {
+      if (blob != null) {
+        const file = blob;
+        const storageRef = ref(firebaseStorage, `social/${userId + "_" + date}`);
+        uploadBytes(storageRef, file).then((snapshot) =>
+          getDownloadURL(snapshot.ref).then((downloadURL) =>
+            plannerApi.social(userId, { date, socialImage: downloadURL }).catch((err) => console.error(err)),
+          ),
+        );
+      }
     });
   };
 

--- a/FE/src/pages/Planner/DayPage.tsx
+++ b/FE/src/pages/Planner/DayPage.tsx
@@ -13,6 +13,7 @@ import { plannerApi } from "@api/Api";
 import { selectUserId } from "@store/authSlice";
 import { ref, uploadBytes, getDownloadURL } from "firebase/storage";
 import { firebaseStorage } from "@api/firebaseConfig";
+import { resizeImage } from "@util/resizeImage";
 import html2canvas from "html2canvas";
 import { selectFriendId } from "@store/friendSlice";
 
@@ -148,7 +149,7 @@ const DayPage = () => {
     });
     canvas.toBlob(async (blob) => {
       if (blob != null) {
-        const file = blob;
+        const file = await resizeImage(blob);
         const storageRef = ref(firebaseStorage, `social/${userId + "_" + date}`);
         uploadBytes(storageRef, file).then((snapshot) =>
           getDownloadURL(snapshot.ref).then((downloadURL) =>

--- a/FE/src/util/resizeImage.ts
+++ b/FE/src/util/resizeImage.ts
@@ -7,10 +7,10 @@ const dataURItoBlob = function (dataURI: string) {
   return new Blob([ia], { type: mimeString });
 };
 
-export const resizeImage = (file: File): Promise<Blob> => {
+export const resizeImage = (file: File | Blob): Promise<Blob> => {
   const canvas = document.createElement("canvas");
   const base_size = 256000; //250KB // 파일 압축 기준 사이즈
-  const comp_size = 51200; //50KB (25~100KB 수준으로 압축)
+  const comp_size = 51200; //50KB
 
   return new Promise((resolve, reject) => {
     const image = new Image();
@@ -20,7 +20,7 @@ export const resizeImage = (file: File): Promise<Blob> => {
       let height = image.height;
       if (file.size <= base_size) return resolve(file);
 
-      const ratio = Math.ceil(file.size / comp_size);
+      const ratio = Math.ceil(Math.sqrt(file.size / comp_size));
       width = image.width / ratio;
       height = image.height / ratio;
       canvas.width = width;

--- a/FE/src/util/resizeImage.ts
+++ b/FE/src/util/resizeImage.ts
@@ -1,0 +1,33 @@
+const dataURItoBlob = function (dataURI: string) {
+  const byteString = atob(dataURI.split(",")[1]);
+  const mimeString = dataURI.split(",")[0].split(":")[1].split(";")[0];
+  const ab = new ArrayBuffer(byteString.length);
+  const ia = new Uint8Array(ab);
+  for (var i = 0; i < byteString.length; i++) ia[i] = byteString.charCodeAt(i);
+  return new Blob([ia], { type: mimeString });
+};
+
+export const resizeImage = (file: File): Promise<Blob> => {
+  const canvas = document.createElement("canvas");
+  const base_size = 256000; //250KB // 파일 압축 기준 사이즈
+  const comp_size = 51200; //50KB (25~100KB 수준으로 압축)
+
+  return new Promise((resolve, reject) => {
+    const image = new Image();
+    image.src = URL.createObjectURL(file);
+    image.onload = () => {
+      let width = image.width;
+      let height = image.height;
+      if (file.size <= base_size) return resolve(file);
+
+      const ratio = Math.ceil(file.size / comp_size);
+      width = image.width / ratio;
+      height = image.height / ratio;
+      canvas.width = width;
+      canvas.height = height;
+      canvas.getContext("2d")?.drawImage(image, 0, 0, width, height);
+      return resolve(dataURItoBlob(canvas.toDataURL("image/png")));
+    };
+    image.onerror = reject;
+  });
+};


### PR DESCRIPTION
close #459

## 어떤 이유로 MR를 하셨나요?

- [ ] test 코드 작성
- [ ] feature 병합
- [ ] 버그 수정
- [x] 코드 개선
- [ ] 기타(아래에 자세한 내용 기입해주세요)

## 세부 내용 - 왜 해당 MR이 필요한지 자세하게 설명해주세요

- 이미지 확장자 png, jpg/jepg로 제한 
- 이미지 파이어베이스에 리사이징 업로드
  - 250KB보다 클 경우 리사이징 함수 실행
  - 화질 많이 깨지지 않게 하기 위해 (파일 사이즈/목표 사이즈)의 제곱근으로 리사이징 함
  - 테스트 결과, 1.49MB → 382.44KB

## MR하기 전에 확인해주세요

- [x] 커밋 컨벤션을 맞췄나요?
- [x] 오류나는 코드는 없나요?
