### PR TITLE
[FE] 일별 플래너에서 공유 취소 및 삭제 API 연결

### DIFF
--- a/FE/src/components/planner/day/Header.tsx
+++ b/FE/src/components/planner/day/Header.tsx
@@ -11,7 +11,7 @@ import { setDayDate, selectDayDate, selectDayInfo, setDayLike, setDayInfo } from
 import dayjs from "dayjs";
 import "dayjs/locale/ko";
 import { selectFriendInfo } from "@store/friendSlice";
-import { plannerApi } from "@api/Api";
+import { plannerApi, socialApi } from "@api/Api";
 import { selectUserId } from "@store/authSlice";
 import { setThisWeek } from "@store/planner/weekSlice";
 import { getThisWeek } from "@util/getThisWeek";
@@ -64,14 +64,21 @@ const FriendHeader = () => {
 
 const MyHeader = ({ socialClick }: { socialClick: () => Promise<void> }) => {
   const dispatch = useAppDispatch();
+  const userId = useAppSelector(selectUserId);
   const dayPlannerInfo = useAppSelector(selectDayInfo);
   const { plannerAccessScope, likeCount, shareSocial, dailyTodos } = dayPlannerInfo;
 
   function handleClick() {
-    if (!shareSocial) {
-      dispatch(setDayInfo({ ...dayPlannerInfo, shareSocial: true }));
+    if (shareSocial == 0) {
       socialClick();
-    } else dispatch(setDayInfo({ ...dayPlannerInfo, shareSocial: false }));
+    } else {
+      socialApi
+        .delete(userId, shareSocial)
+        .then(() => {
+          dispatch(setDayInfo({ ...dayPlannerInfo, shareSocial: 0 }));
+        })
+        .catch((err) => console.error("공유된 소셜 삭제", err));
+    }
   }
 
   return (

--- a/FE/src/pages/Planner/DayPage.tsx
+++ b/FE/src/pages/Planner/DayPage.tsx
@@ -45,7 +45,6 @@ const DayPage = () => {
       .daily(friendUserId, { date: day })
       .then((res) => {
         const response = res.data.data;
-        console.log(response);
         dispatch(
           setDayInfo({
             plannerAccessScope: response.plannerAccessScope,

--- a/FE/src/store/planner/daySlice.ts
+++ b/FE/src/store/planner/daySlice.ts
@@ -12,7 +12,7 @@ interface dayInfoConfig {
   dday: string | null;
   like: boolean;
   likeCount: number;
-  shareSocial: boolean;
+  shareSocial: number;
   dailyTodos: TodoConfig[];
 }
 
@@ -29,7 +29,7 @@ const initialState: dayConfig = {
     dday: null,
     like: false,
     likeCount: 0,
-    shareSocial: false,
+    shareSocial: 0,
     dailyTodos: [],
   },
   todoItem: {


### PR DESCRIPTION
close #484

## 어떤 이유로 MR를 하셨나요?

- [ ] test 코드 작성
- [x] feature 병합
- [ ] 버그 수정
- [ ] 코드 개선
- [ ] 기타(아래에 자세한 내용 기입해주세요)

## 세부 내용 - 왜 해당 MR이 필요한지 자세하게 설명해주세요

- 플래너에서 소셜 공유 해제시 '공유취소' 글씨 보이기
- 공유취소시에는 플래너 삭제 모달을 보이고, 삭제 버튼을 누를시 공유된 플래너 삭제
  > console.log에 있는 key 에러랑 timeTable 클릭시 공유되는 사항은 [다른 pr](https://github.com/NewSainTurtle/ShadowMate/pull/476)에서 수정한 문제로 무시하고 검토해주세요.

## MR하기 전에 확인해주세요

- [x] 커밋 컨벤션을 맞췄나요?
- [x] 오류나는 코드는 없나요?
