### PR TITLE
[FE] 주별 플래너 Safari 에러 수정

### DIFF
--- a/FE/src/components/planner/week/list/WeekList.tsx
+++ b/FE/src/components/planner/week/list/WeekList.tsx
@@ -68,7 +68,7 @@ const WeekList = ({ idx, isMine, today, retroClick, setRetroClick }: Props) => {
         <div onClick={handleMoveToDay}>
           <Text>{dateFormat(date)}</Text>
         </div>
-        <Dday nearDate={nearDate} comparedDate={dateFormat(date)} />
+        <Dday nearDate={nearDate} comparedDate={date} />
       </div>
       <div className={styles["item__todo-list"]} style={{ gridTemplateRows: `repeat(${rowMaxLength}, 20%` }}>
         {dailyTodos.map((item: TodoConfig, key: number) => (

--- a/FE/src/styles/planner/Week.module.scss
+++ b/FE/src/styles/planner/Week.module.scss
@@ -278,6 +278,7 @@ $border: 1px;
   }
 
   &__memo {
+    height: 100%;
     position: relative;
     > textarea {
       background: transparent;


### PR DESCRIPTION
close #562 

## 어떤 이유로 MR를 하셨나요?

- [ ] test 코드 작성
- [ ] feature 병합
- [x] 버그 수정
- [ ] 코드 개선
- [ ] 기타(아래에 자세한 내용 기입해주세요)

## 세부 내용 - 왜 해당 MR이 필요한지 자세하게 설명해주세요

- 주별 플래너 회고 높이 설정 -> 메모장 되어버리는 에러 수정
- 주별 플래너 디데이 `compareDate`로 넘기는 변수 수정 -> `D+NaN`으로 나오는 에러 수정
- 기존:
<img width="1000" alt="스크린샷 2024-01-04 오후 3 28 31" src="https://github.com/NewSainTurtle/ShadowMate/assets/85155789/2909bedd-3299-4951-ae5b-94aa0b2140a4">
- 수정:
<img width="1000" alt="스크린샷 2024-01-04 오후 3 28 09" src="https://github.com/NewSainTurtle/ShadowMate/assets/85155789/9f016691-9481-4e26-9764-409f36d2e59c">

## MR하기 전에 확인해주세요

- [x] 커밋 컨벤션을 맞췄나요?
- [x] 오류나는 코드는 없나요?
