### PR TITLE
[FE] 할 일 타임테이블 중복 표시

### DIFF
--- a/FE/src/api/Api.ts
+++ b/FE/src/api/Api.ts
@@ -86,7 +86,7 @@ export const plannerApi = {
 
   timetables: (userId: number, data: { date: string; todoId: number; startTime: string; endTime: string }) =>
     Axios.post(api.planners.timetables(userId), data),
-  deleteTimetable: (userId: number, data: { date: string; todoId: number }) =>
+  deleteTimetable: (userId: number, data: { date: string; todoId: number; timeTableId: number }) =>
     Axios.delete(api.planners.timetables(userId), { data: data }),
   retrospections: (userId: number, data: { date: string; retrospection: string }) =>
     Axios.put(api.planners.retrospections(userId), data),

--- a/FE/src/components/planner/day/todo/TimeTable.tsx
+++ b/FE/src/components/planner/day/todo/TimeTable.tsx
@@ -118,8 +118,9 @@ const TimeTable = ({ clicked, setClicked }: Props) => {
       await Promise.resolve(
         todoList.map((item: TodoConfig) => {
           item.timeTables?.map((time) => {
-            if (!(dayjs(time.endTime).isSameOrBefore(startTime) || dayjs(time.startTime).isSameOrAfter(endTime)))
+            if (!(dayjs(time.endTime).isSameOrBefore(startTime) || dayjs(time.startTime).isSameOrAfter(endTime))) {
               deleteTimeTable(item.todoId, time.timeTableId);
+            }
           });
         }),
       );
@@ -128,7 +129,7 @@ const TimeTable = ({ clicked, setClicked }: Props) => {
     await plannerApi
       .timetables(userId, { date, todoId, startTime, endTime })
       .then((res) => {
-        const timeTableId = res.data.timeTabled;
+        const { timeTableId } = res.data.data;
         dispatch(setTimeTable({ todoId, timeTableId, startTime, endTime }));
         setSelectTime({ startTime: "", endTime: "" });
       })

--- a/FE/src/components/planner/day/todo/TimeTable.tsx
+++ b/FE/src/components/planner/day/todo/TimeTable.tsx
@@ -72,7 +72,7 @@ const TimeTable = ({ clicked, setClicked }: Props) => {
   const handleDeleteModalClose = () => setDeleteModalOpen(false);
   const count = useMemo(() => {
     const status = todoList.filter((ele) => ele.todoStatus == "완료" || ele.todoStatus == "진행중").length;
-    const saveTime = todoList.filter((ele) => ele.timeTable && ele.timeTable.startTime != "").length;
+    const saveTime = todoList.filter((ele) => ele.timeTables && ele.timeTables.startTime != "").length;
     return { status, saveTime };
   }, [todoList]);
 
@@ -92,7 +92,7 @@ const TimeTable = ({ clicked, setClicked }: Props) => {
       if (todoId != 0) {
         setTimeClicked(false);
 
-        if (selectItem.timeTable && selectItem.timeTable.startTime != "")
+        if (selectItem.timeTables && selectItem.timeTables.startTime != "")
           deleteTimeTable(todoId).then(() => saveTimeTable(endTime));
         else saveTimeTable(endTime);
       }
@@ -114,11 +114,11 @@ const TimeTable = ({ clicked, setClicked }: Props) => {
 
     await Promise.resolve(
       todoList.map((item: TodoConfig) => {
-        if (item.timeTable && !!item.timeTable.startTime) {
+        if (item.timeTables && !!item.timeTables.startTime) {
           if (
             !(
-              dayjs(item.timeTable.endTime).isSameOrBefore(startTime) ||
-              dayjs(item.timeTable.startTime).isSameOrAfter(endTime)
+              dayjs(item.timeTables.endTime).isSameOrBefore(startTime) ||
+              dayjs(item.timeTables.startTime).isSameOrAfter(endTime)
             )
           )
             deleteTimeTable(item.todoId);
@@ -145,11 +145,10 @@ const TimeTable = ({ clicked, setClicked }: Props) => {
   useEffect(() => {
     let tempArr = [...makeTimeArr];
     todoList
-      .filter((ele: TodoConfig) => ele.timeTable && ele.timeTable.startTime != "" && ele.timeTable.endTime != "")
+      .filter((ele: TodoConfig) => ele.timeTables && ele.timeTables.startTime != "" && ele.timeTables.endTime != "")
       .map((item: TodoConfig) => {
-        const { todoId, category } = item;
-        const timeTable = item.timeTable as TimeTableConfig;
-        let { startTime, endTime } = timeTable;
+        const { todoId, category, timeTables } = item;
+        let { startTime, endTime } = timeTables as TimeTableConfig;
         const miniArr: TimeTableType[] = [];
         let tempTime = startTime;
         while (tempTime != endTime) {

--- a/FE/src/components/planner/day/todo/TimeTable.tsx
+++ b/FE/src/components/planner/day/todo/TimeTable.tsx
@@ -74,7 +74,7 @@ const TimeTable = ({ clicked, setClicked }: Props) => {
   });
   const handleDeleteModalOpen = () => setDeleteModalOpen(true);
   const handleDeleteModalClose = () => setDeleteModalOpen(false);
-  const count = useMemo(() => {
+  const activeTodoCount = useMemo(() => {
     const status = todoList.filter((ele) => ele.todoStatus == "완료" || ele.todoStatus == "진행중").length;
     const saveTime = todoList.filter((ele) => ele.timeTables).length;
     return { status, saveTime };
@@ -188,15 +188,15 @@ const TimeTable = ({ clicked, setClicked }: Props) => {
   }, [selectTime]);
 
   const timeTableClick = () => {
-    if (count.status > 0) setClicked(true);
+    if (activeTodoCount.status > 0) setClicked(true);
   };
 
   const timeTableStyle = (() => {
-    if (todoId != 0 && count.saveTime == 0) return "--dragBefore";
-    if (clicked && count.saveTime == 0) return "--clicked";
-    if (timeClick || count.saveTime != 0) return "--drag";
+    if (todoId != 0 && activeTodoCount.saveTime == 0) return "--dragBefore";
+    if (clicked && activeTodoCount.saveTime == 0) return "--clicked";
+    if (timeClick || activeTodoCount.saveTime != 0) return "--drag";
     if (!todoList.length) return "--none";
-    if (count.status == 0) return "--stateNone";
+    if (activeTodoCount.status == 0) return "--stateNone";
     return "--defalut";
   })();
 

--- a/FE/src/components/planner/day/todo/TodoItem.tsx
+++ b/FE/src/components/planner/day/todo/TodoItem.tsx
@@ -18,7 +18,7 @@ interface Props {
     insertTodo: (props: TodoConfig) => void;
     updateTodo: (idx: number, props: TodoConfig) => void;
     deleteTodo: (idx: number, todoId: number) => void;
-    deleteTimeTable: (todoId: number, todoStatus: TodoConfig["todoStatus"]) => void;
+    deleteTimeTable: (todoId: number, timeTableId: number, todoStatus: TodoConfig["todoStatus"]) => void;
   };
 }
 
@@ -197,7 +197,7 @@ const TodoItem = ({ idx = -1, todoItem, addTodo, disable, todoModule }: Props) =
         open={warnModalOpen}
         onClose={handleWarnModalClose}
         onClick={() => {
-          deleteTimeTable(todoItem.todoId, "미완료");
+          deleteTimeTable(todoItem.todoId, todoItem.timeTables?.timeTableId as number, "미완료");
           handleWarnModalClose();
         }}
         onClickMessage="확인"

--- a/FE/src/components/planner/day/todo/TodoItem.tsx
+++ b/FE/src/components/planner/day/todo/TodoItem.tsx
@@ -87,7 +87,7 @@ const TodoItem = ({ idx = -1, todoItem, addTodo, disable, todoModule }: Props) =
   const handleSaveStatusTodo = () => {
     if (text === "") return;
     if (todoStatus === "진행중") {
-      if (todoItem.timeTable && todoItem.timeTable.startTime != "") {
+      if (todoItem.timeTables && todoItem.timeTables.startTime != "") {
         handleWarnModalOpen();
       } else {
         updateTodo(idx, {

--- a/FE/src/components/planner/day/todo/TodoItem.tsx
+++ b/FE/src/components/planner/day/todo/TodoItem.tsx
@@ -7,7 +7,7 @@ import CategorySelector from "@components/common/CategorySelector";
 import TimeTableDeleteModal from "@components/common/Modal/TimeTableDeleteModal";
 import { AddOutlined, DeleteOutlined } from "@mui/icons-material";
 import { BASIC_CATEGORY_ITEM } from "@store/planner/daySlice";
-import { TodoConfig, CategoryItemConfig } from "@util/planner.interface";
+import { TodoConfig, CategoryItemConfig, TimeTableConfig } from "@util/planner.interface";
 
 interface Props {
   idx?: number;
@@ -18,7 +18,7 @@ interface Props {
     insertTodo: (props: TodoConfig) => void;
     updateTodo: (idx: number, props: TodoConfig) => void;
     deleteTodo: (idx: number, todoId: number) => void;
-    deleteTimeTable: (todoId: number, timeTableId: number, todoStatus: TodoConfig["todoStatus"]) => void;
+    deleteTimeTable: (todoId: number, timeTables: TimeTableConfig[], todoStatus: TodoConfig["todoStatus"]) => void;
   };
 }
 
@@ -87,7 +87,7 @@ const TodoItem = ({ idx = -1, todoItem, addTodo, disable, todoModule }: Props) =
   const handleSaveStatusTodo = () => {
     if (text === "") return;
     if (todoStatus === "진행중") {
-      if (todoItem.timeTables && todoItem.timeTables.startTime != "") {
+      if (todoItem.timeTables && todoItem.timeTables.length > 0) {
         handleWarnModalOpen();
       } else {
         updateTodo(idx, {
@@ -197,7 +197,7 @@ const TodoItem = ({ idx = -1, todoItem, addTodo, disable, todoModule }: Props) =
         open={warnModalOpen}
         onClose={handleWarnModalClose}
         onClick={() => {
-          deleteTimeTable(todoItem.todoId, todoItem.timeTables?.timeTableId as number, "미완료");
+          deleteTimeTable(todoItem.todoId, todoItem.timeTables as TimeTableConfig[], "미완료");
           handleWarnModalClose();
         }}
         onClickMessage="확인"

--- a/FE/src/components/planner/day/todo/TodoList.tsx
+++ b/FE/src/components/planner/day/todo/TodoList.tsx
@@ -114,7 +114,7 @@ const TodoList = ({ clicked }: Props) => {
                 key={item.todoId}
                 idx={idx}
                 todoItem={item}
-                possible={todoFilter && !item.timeTable?.startTime}
+                possible={todoFilter && !item.timeTables?.startTime}
               />
             );
           })}

--- a/FE/src/components/planner/day/todo/TodoList.tsx
+++ b/FE/src/components/planner/day/todo/TodoList.tsx
@@ -63,9 +63,9 @@ const TodoList = ({ clicked }: Props) => {
         });
     };
 
-    const deleteTimeTable = async (todoId: number, todoStatus: TodoConfig["todoStatus"]) => {
+    const deleteTimeTable = async (todoId: number, timeTableId: number, todoStatus: TodoConfig["todoStatus"]) => {
       await plannerApi
-        .deleteTimetable(userId, { date, todoId: todoId })
+        .deleteTimetable(userId, { date, todoId, timeTableId })
         .then(() => dispatch(setTimeTable({ todoId, startTime: "", endTime: "", todoStatus })));
     };
 

--- a/FE/src/components/planner/day/todo/TodoList.tsx
+++ b/FE/src/components/planner/day/todo/TodoList.tsx
@@ -3,7 +3,7 @@ import styles from "@styles/planner/day.module.scss";
 import TodoItem from "@components/planner/day/todo/TodoItem";
 import { useAppDispatch, useAppSelector } from "@hooks/hook";
 import { BASIC_TODO_ITEM, setTodoList, selectTodoList, selectDayDate, setTimeTable } from "@store/planner/daySlice";
-import { TodoConfig } from "@util/planner.interface";
+import { TimeTableConfig, TodoConfig } from "@util/planner.interface";
 import TodoItemChoice from "./TodoItemChoice";
 import { plannerApi } from "@api/Api";
 import { selectUserId } from "@store/authSlice";
@@ -63,10 +63,16 @@ const TodoList = ({ clicked }: Props) => {
         });
     };
 
-    const deleteTimeTable = async (todoId: number, timeTableId: number, todoStatus: TodoConfig["todoStatus"]) => {
-      await plannerApi
-        .deleteTimetable(userId, { date, todoId, timeTableId })
-        .then(() => dispatch(setTimeTable({ todoId, startTime: "", endTime: "", todoStatus })));
+    /**
+     * todo 상태를 "미완료"로 변경시 등록된 타임테이블 모두 삭제
+     */
+    const deleteTimeTable = (todoId: number, timeTables: TimeTableConfig[], todoStatus: TodoConfig["todoStatus"]) => {
+      timeTables.map(async (item) => {
+        const { timeTableId } = item;
+        await plannerApi
+          .deleteTimetable(userId, { date, todoId, timeTableId })
+          .then(() => dispatch(setTimeTable({ todoId, timeTableId, startTime: "", endTime: "", todoStatus })));
+      });
     };
 
     const deleteTodo = async (idx: number, todoId: number) => {
@@ -107,17 +113,14 @@ const TodoList = ({ clicked }: Props) => {
         </>
       ) : (
         <>
-          {todoArr.map((item: TodoConfig, idx: number) => {
-            const todoFilter = item.todoStatus === "완료" || item.todoStatus === "진행중";
-            return (
-              <TodoItemChoice
-                key={item.todoId}
-                idx={idx}
-                todoItem={item}
-                possible={todoFilter && !item.timeTables?.startTime}
-              />
-            );
-          })}
+          {todoArr.map((item: TodoConfig, idx: number) => (
+            <TodoItemChoice
+              key={item.todoId}
+              idx={idx}
+              todoItem={item}
+              possible={item.todoStatus === "완료" || item.todoStatus === "진행중"}
+            />
+          ))}
           {Array.from({ length: listSize - todoArr.length }).map((_, idx) => (
             <TodoItemChoice key={idx} todoItem={BASIC_TODO_ITEM} possible={false} disable />
           ))}

--- a/FE/src/pages/Planner/DayPage.tsx
+++ b/FE/src/pages/Planner/DayPage.tsx
@@ -66,10 +66,10 @@ const DayPage = () => {
 
   useEffect(() => {
     const sumMinute = todoList
-      .filter((ele: TodoConfig) => ele.timeTable && ele.timeTable.startTime != "" && ele.timeTable.endTime != "")
+      .filter((ele: TodoConfig) => ele.timeTables && ele.timeTables.startTime != "" && ele.timeTables.endTime != "")
       .reduce(
-        (accumulator: number, item: { timeTable: TimeTableConfig }) =>
-          accumulator + Number(dayjs(item.timeTable.endTime).diff(dayjs(item.timeTable.startTime), "m")),
+        (accumulator: number, item: { timeTables: TimeTableConfig }) =>
+          accumulator + Number(dayjs(item.timeTables.endTime).diff(dayjs(item.timeTables.startTime), "m")),
         0,
       );
     const studyTimeHour = Math.floor(sumMinute / 60);

--- a/FE/src/pages/Planner/DayPage.tsx
+++ b/FE/src/pages/Planner/DayPage.tsx
@@ -66,7 +66,7 @@ const DayPage = () => {
 
   useEffect(() => {
     const sumMinute = todoList
-      .filter((ele: TodoConfig) => ele.timeTables && ele.timeTables.startTime != "" && ele.timeTables.endTime != "")
+      .filter((ele: TodoConfig) => ele.timeTables && ele.timeTables.length > 0)
       .reduce(
         (accumulator: number, item: { timeTables: TimeTableConfig }) =>
           accumulator + Number(dayjs(item.timeTables.endTime).diff(dayjs(item.timeTables.startTime), "m")),

--- a/FE/src/pages/Planner/DayPage.tsx
+++ b/FE/src/pages/Planner/DayPage.tsx
@@ -23,7 +23,7 @@ const DayPage = () => {
   let friendUserId = useAppSelector(selectFriendId);
   friendUserId = friendUserId != 0 ? friendUserId : userId;
   const date = useAppSelector(selectDayDate);
-  const todoList = useAppSelector(selectTodoList);
+  const todoList: TodoConfig[] = useAppSelector(selectTodoList);
   const dayPlannerInfo = useAppSelector(selectDayInfo);
   const [ment, setMent] = useState({
     todayGoal: "",
@@ -65,13 +65,14 @@ const DayPage = () => {
   }, [date, friendUserId]);
 
   useEffect(() => {
-    const sumMinute = todoList
-      .filter((ele: TodoConfig) => ele.timeTables && ele.timeTables.length > 0)
-      .reduce(
-        (accumulator: number, item: { timeTables: TimeTableConfig }) =>
-          accumulator + Number(dayjs(item.timeTables.endTime).diff(dayjs(item.timeTables.startTime), "m")),
-        0,
-      );
+    const sumMinute = todoList.reduce((accumulate: number, ele: TodoConfig) => {
+      const sumTodoTime = ele.timeTables?.reduce((sumTime: number, item: TimeTableConfig) => {
+        return sumTime + Number(dayjs(item.endTime).diff(dayjs(item.startTime), "m"));
+      }, 0) as number;
+      console.log(sumTodoTime);
+      return accumulate + sumTodoTime;
+    }, 0);
+
     const studyTimeHour = Math.floor(sumMinute / 60);
     const studyTimeMinute = Math.floor(sumMinute % 60);
     setTotalTime({ studyTimeHour, studyTimeMinute });

--- a/FE/src/store/planner/daySlice.ts
+++ b/FE/src/store/planner/daySlice.ts
@@ -44,7 +44,7 @@ const initialState: DayConfig = {
       categoryColorCode: "#E9E9EB",
       categoryEmoticon: "",
     },
-    timeTable: {
+    timeTables: {
       timeTableId: 0,
       startTime: "",
       endTime: "",
@@ -92,7 +92,7 @@ const daySlice = createSlice({
       tempArr[findIndex] = {
         ...todoInfo,
         todoStatus,
-        timeTable: { ...todoInfo.timeTable!, startTime, endTime },
+        timeTables: { ...todoInfo.timeTables!, startTime, endTime },
       };
 
       state.info.dailyTodos = tempArr;

--- a/FE/src/store/planner/daySlice.ts
+++ b/FE/src/store/planner/daySlice.ts
@@ -1,6 +1,6 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { rootState } from "@hooks/configStore";
-import { TodoConfig } from "@util/planner.interface";
+import { TimeTableConfig, TodoConfig } from "@util/planner.interface";
 import dayjs from "dayjs";
 import isSameOrBefore from "dayjs/plugin/isSameOrBefore";
 import isSameOrAfter from "dayjs/plugin/isSameOrAfter";
@@ -44,11 +44,7 @@ const initialState: DayConfig = {
       categoryColorCode: "#E9E9EB",
       categoryEmoticon: "",
     },
-    timeTables: {
-      timeTableId: 0,
-      startTime: "",
-      endTime: "",
-    },
+    timeTables: [],
   },
 };
 
@@ -78,21 +74,32 @@ const daySlice = createSlice({
       state,
       action: PayloadAction<{
         todoId: number;
-        startTime: string;
-        endTime: string;
+        timeTableId: number;
+        startTime?: string;
+        endTime?: string;
         todoStatus?: TodoConfig["todoStatus"];
       }>,
     ) => {
-      const { todoId, startTime, endTime } = action.payload;
+      const { todoId, timeTableId, startTime, endTime } = action.payload;
 
       const tempArr = state.info.dailyTodos;
-      const findIndex = tempArr.findIndex((item) => item.todoId == todoId);
-      const todoInfo = tempArr[findIndex] as TodoConfig;
+      const findTodoIndex = tempArr.findIndex((item) => item.todoId == todoId);
+      const todoInfo = tempArr[findTodoIndex] as TodoConfig;
       const todoStatus = action.payload.todoStatus || todoInfo.todoStatus;
-      tempArr[findIndex] = {
+      const todoTimetable = (() => {
+        let tempTimeTable = todoInfo.timeTables ?? [];
+        if (startTime) return [...tempTimeTable, { timeTableId, startTime, endTime }];
+        else {
+          const findTimeIndex = tempTimeTable?.findIndex((item) => item.timeTableId === timeTableId) as number;
+          tempTimeTable?.splice(findTimeIndex, 1);
+          return tempTimeTable;
+        }
+      })() as TimeTableConfig[];
+
+      tempArr[findTodoIndex] = {
         ...todoInfo,
         todoStatus,
-        timeTables: { ...todoInfo.timeTables!, startTime, endTime },
+        timeTables: todoTimetable,
       };
 
       state.info.dailyTodos = tempArr;

--- a/FE/src/util/planner.interface.ts
+++ b/FE/src/util/planner.interface.ts
@@ -44,7 +44,7 @@ export interface TodoConfig {
   todoContent: string;
   todoStatus: "공백" | "완료" | "진행중" | "미완료";
   todoUpdate?: boolean;
-  timeTables?: TimeTableConfig | null;
+  timeTables?: TimeTableConfig[] | null;
 }
 
 /* --- Week Interfaces --- */

--- a/FE/src/util/planner.interface.ts
+++ b/FE/src/util/planner.interface.ts
@@ -44,7 +44,7 @@ export interface TodoConfig {
   todoContent: string;
   todoStatus: "공백" | "완료" | "진행중" | "미완료";
   todoUpdate?: boolean;
-  timeTable?: TimeTableConfig | null;
+  timeTables?: TimeTableConfig | null;
 }
 
 /* --- Week Interfaces --- */


### PR DESCRIPTION
close #593 

## 어떤 이유로 MR를 하셨나요?

- [ ] test 코드 작성
- [x] feature 병합
- [ ] 버그 수정
- [x] 코드 개선
- [ ] 기타(아래에 자세한 내용 기입해주세요)

## 세부 내용 - 왜 해당 MR이 필요한지 자세하게 설명해주세요

- 타임테이블 추가/삭제 API 수정
- 할 일 타임테이블 중복 허용
  - 타임테이블 관련 타입 변경(객체 → 배열)
  - 할 일 1개에 시간 2개 이상 등록 가능( todo : timeTable = 1:N)
  - 시간 계산 로직 변경

( 타임 테이블 등록 시 다른 할 일의 시간과 겹칠 경우, 기존 방식대로 이 전 할 일의 겹치는 시간만 삭제합니다.  
이전에 말씀드렸던 삭제하지 않고 겹치는 시간 계산해서 저장하는 방식은 남은 이슈 먼저 해결 후 처리하겠습니다.) 

## MR하기 전에 확인해주세요

- [ ] 커밋 컨벤션을 맞췄나요?
- [ ] 오류나는 코드는 없나요?
