### PR TITLE
[FE] 토큰 재발급 로직 추가

### DIFF
--- a/FE/src/App.tsx
+++ b/FE/src/App.tsx
@@ -57,14 +57,14 @@ const App = () => {
     setPathName(["/day", "/week", "/month", "/social", "/mypage", "/search", "/category"].includes(location.pathname));
   }, [location.pathname]);
 
-  useEffect(() => {
-    // 자동 로그인 확인 시
-    const accessToken = localStorage.getItem("accessToken") ?? "";
-    const id = localStorage.getItem("id");
-    let userId = 0;
-    if (id) userId = parseInt(id);
-    if (accessToken && id) dispatch(setLogin({ accessToken: accessToken, userId: userId }));
-  }, []);
+  // 자동로그인 구현 시 추가
+  // useEffect(() => {
+  //   const accessToken = localStorage.getItem("accessToken") ?? "";
+  //   const id = localStorage.getItem("id");
+  //   let userId = 0;
+  //   if (id) userId = parseInt(id);
+  //   if (accessToken && id) dispatch(setLogin({ accessToken: accessToken, userId: userId }));
+  // }, []);
 
   return (
     <div className={pathName ? styles["App__header"] : ""}>

--- a/FE/src/api/Api.ts
+++ b/FE/src/api/Api.ts
@@ -11,6 +11,7 @@ export const authApi = {
   emailAuthentication: (data: { email: string }) => Axios.post(api.auth.emailAuthentication(), data),
   emailAuthenticationCheck: (data: { email: string; code: string }) =>
     Axios.post(api.auth.emailAuthenticationCheck(), data),
+  token: (userId: number, data: { type: string }) => Axios.post(api.auth.token(userId), data),
 };
 
 export const userApi = {

--- a/FE/src/api/BaseUrl.ts
+++ b/FE/src/api/BaseUrl.ts
@@ -17,6 +17,7 @@ interface apiInterface {
     nickname: () => string; // 닉네임 중복검사, 삭제
     emailAuthentication: () => string; // 이메일 인증 (+중복검사)
     emailAuthenticationCheck: () => string; // 이메일 인증 - 응답
+    token: (userId: number) => string; // 토큰 재발급
   };
   users: {
     getProfiles: (userId: number) => string; // 프로필 조회
@@ -71,6 +72,7 @@ const api: apiInterface = {
     nickname: () => HOST + AUTH + "nickname-duplicated",
     emailAuthentication: () => HOST + AUTH + "email-authentication",
     emailAuthenticationCheck: () => HOST + AUTH + "email-authentication" + "/check",
+    token: (userId: number) => HOST + AUTH + "token/" + userId,
   },
   users: {
     getProfiles: (userId: number) => HOST + USERS + userId + "/profiles",

--- a/FE/src/api/JsonAxios.ts
+++ b/FE/src/api/JsonAxios.ts
@@ -1,5 +1,7 @@
 import baseAxios from "axios";
 import { store } from "@hooks/configStore";
+import { authApi } from "@api/Api";
+import { setAccessToken, setLogout } from "@store/authSlice";
 import { setModalOpen } from "@store/modalSlice";
 import { setAlertOpen } from "@store/alertSlice";
 
@@ -30,9 +32,26 @@ Axios.interceptors.response.use(
     }
     return res;
   },
-  (err) => {
-    if (err.response.data.code === "FAIL_VALIDATE_TOKEN") {
-      store.dispatch(setModalOpen());
+  async (err) => {
+    const {
+      config,
+      response: { status },
+    } = err;
+
+    if (status === 401) {
+      if (err.response.data.code === "EXPIRED_ACCESS_TOKEN") {
+        const userId = store.getState().auth.userId;
+        const type = store.getState().auth.type;
+        const res = await authApi.token(userId, type);
+        if (res.status === 200) {
+          const accessToken = res.headers["authorization"].replace("Bearer ", "");
+          store.dispatch(setAccessToken(accessToken));
+          config.headers.Authorization = `Bearer ${accessToken}`;
+          return Axios(config);
+        }
+      } else if (err.response.data.code === "EXPIRED_REFRESH_TOKEN") {
+        store.dispatch(setModalOpen());
+      }
     }
     return Promise.reject(err);
   },

--- a/FE/src/components/auth/login/Login.tsx
+++ b/FE/src/components/auth/login/Login.tsx
@@ -57,6 +57,9 @@ const Login = () => {
         setShowAlert(false);
         const accessToken = res.headers["authorization"];
         const userId = res.headers["id"];
+        const type = res.headers["type"];
+        const auto = res.headers["Auto-Login"] ?? ""; // 자동로그인 아닐 때는 header에 정보 없음.
+        dispatch(setLogin({ accessToken, userId, type, autoLogin: auto }));
         // if (auto && auto === "true") {
         //   localStorage.clear();
         //   localStorage.setItem("accessToken", accessToken);
@@ -79,11 +82,13 @@ const Login = () => {
   useEffect(() => {
     const token = getCookie("token");
     const id = getCookie("userId");
-    if (token && id) {
-      dispatch(setLogin({ accessToken: token, userId: parseInt(id) }));
+    const type = getCookie("type");
+    if (token && id && type) {
+      dispatch(setLogin({ accessToken: token, userId: parseInt(id), type }));
       dispatch(setIsGoogle(true));
       deleteCookie("token");
       deleteCookie("userId");
+      deleteCookie("type");
       userApi
         .getProfiles(parseInt(id))
         .then((res) => {

--- a/FE/src/components/auth/login/Login.tsx
+++ b/FE/src/components/auth/login/Login.tsx
@@ -57,12 +57,11 @@ const Login = () => {
         setShowAlert(false);
         const accessToken = res.headers["authorization"];
         const userId = res.headers["id"];
-        dispatch(setLogin({ accessToken: accessToken, userId: userId }));
-        if (autoLogin) {
-          localStorage.clear();
-          localStorage.setItem("accessToken", accessToken);
-          localStorage.setItem("id", userId);
-        }
+        // if (auto && auto === "true") {
+        //   localStorage.clear();
+        //   localStorage.setItem("accessToken", accessToken);
+        //   localStorage.setItem("id", userId);
+        // }
 
         userApi.getProfiles(userId).then((res) => {
           dispatch(setUserInfo(res.data.data));

--- a/FE/src/store/authSlice.ts
+++ b/FE/src/store/authSlice.ts
@@ -16,6 +16,8 @@ interface AuthConfig {
   login: boolean;
   isGoogle: boolean;
   userInfo: UserInfoConfig;
+  type: string;
+  autoLogin?: string;
 }
 
 const initialState: AuthConfig = {
@@ -30,28 +32,36 @@ const initialState: AuthConfig = {
     statusMessage: "",
     plannerAccessScope: "",
   },
+  type: "",
+  autoLogin: "",
 };
 
 const authSlice = createSlice({
   name: "auth",
   initialState,
   reducers: {
-    setLogin: (state, { payload }: PayloadAction<{ accessToken: string; userId: number }>) => {
+    setLogin: (
+      state,
+      { payload }: PayloadAction<{ accessToken: string; userId: number; type: string; autoLogin?: string }>,
+    ) => {
       state.login = true;
       state.userId = payload.userId;
       state.accessToken = payload.accessToken;
+      state.type = payload.type;
+      state.autoLogin = payload.autoLogin;
     },
     setIsGoogle: (state, { payload }: PayloadAction<boolean>) => {
       state.isGoogle = payload;
     },
     setLogout: (state) => {
       state.login = false;
-      // localStorage.removeItem("id");
-      // localStorage.removeItem("accessToken");
     },
     setUserInfo: (state, { payload }: PayloadAction<UserInfoConfig>) => {
       const [statusMessage, profileImage] = [payload.statusMessage || "", payload.profileImage || ""];
       state.userInfo = { ...payload, statusMessage, profileImage };
+    },
+    setAccessToken: (state, { payload }: PayloadAction<string>) => {
+      state.accessToken = payload;
     },
   },
   extraReducers: (builder) => {
@@ -60,7 +70,7 @@ const authSlice = createSlice({
   },
 });
 
-export const { setLogin, setLogout, setUserInfo, setIsGoogle } = authSlice.actions;
+export const { setLogin, setLogout, setUserInfo, setIsGoogle, setAccessToken } = authSlice.actions;
 export const selectUserInfo = (state: rootState) => state.auth.userInfo;
 export const selectLoginState = (state: rootState) => state.auth.login;
 export const selectAccessToken = (state: rootState) => state.auth.accessToken;

--- a/FE/src/store/authSlice.ts
+++ b/FE/src/store/authSlice.ts
@@ -46,8 +46,8 @@ const authSlice = createSlice({
     },
     setLogout: (state) => {
       state.login = false;
-      localStorage.removeItem("id");
-      localStorage.removeItem("accessToken");
+      // localStorage.removeItem("id");
+      // localStorage.removeItem("accessToken");
     },
     setUserInfo: (state, { payload }: PayloadAction<UserInfoConfig>) => {
       const [statusMessage, profileImage] = [payload.statusMessage || "", payload.profileImage || ""];


### PR DESCRIPTION
close #604 

## 어떤 이유로 MR를 하셨나요?

- [ ] test 코드 작성
- [x] feature 병합
- [ ] 버그 수정
- [ ] 코드 개선
- [ ] 기타(아래에 자세한 내용 기입해주세요)

## 세부 내용 - 왜 해당 MR이 필요한지 자세하게 설명해주세요

- 토큰 재발급 API 추가
- 토큰 재발급 로직 추가 (interceptors 사용)
- authSlice에 type (동시 로그인 관련 변수), autoLogin(자동로그인 관련 변수) 추가
- 자동로그인 관련 코드 임시 주석 처리 (추후 관련 이슈 생성 예정)

❗️accessToken 만료 테스트
application.properties / shadowmate.jwt.access.expires=10000 로 하면 10초 뒤 accessToken 재발급 됨.
401 에러는 콘솔에 뜨나, 데이터 잘 가져옴.

## MR하기 전에 확인해주세요

- [x] 커밋 컨벤션을 맞췄나요?
- [x] 오류나는 코드는 없나요?
