### PR TITLE
[BE] 카테고리 삭제 시 루틴 확인

### DIFF
--- a/BE/src/main/java/com/newsainturtle/shadowmate/planner_setting/repository/RoutineRepository.java
+++ b/BE/src/main/java/com/newsainturtle/shadowmate/planner_setting/repository/RoutineRepository.java
@@ -1,5 +1,6 @@
 package com.newsainturtle.shadowmate.planner_setting.repository;
 
+import com.newsainturtle.shadowmate.planner_setting.entity.Category;
 import com.newsainturtle.shadowmate.planner_setting.entity.Routine;
 import com.newsainturtle.shadowmate.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,4 +11,5 @@ public interface RoutineRepository extends JpaRepository<Routine, Long> {
     Routine[] findAllByUser(final User user);
     Routine findByIdAndUser(final Long id, final User user);
     void deleteByIdAndUser(final Long id, final User user);
+    long countByCategory(final Category category);
 }

--- a/BE/src/main/java/com/newsainturtle/shadowmate/planner_setting/service/PlannerSettingServiceImpl.java
+++ b/BE/src/main/java/com/newsainturtle/shadowmate/planner_setting/service/PlannerSettingServiceImpl.java
@@ -202,7 +202,7 @@ public class PlannerSettingServiceImpl extends DateCommonService implements Plan
     @Transactional
     public void removeCategory(final User user, final RemoveCategoryRequest removeCategoryRequest) {
         final Category findCategory = getCategory(user, removeCategoryRequest.getCategoryId());
-        final long count = todoRepository.countByCategory(findCategory);
+        final long count = todoRepository.countByCategory(findCategory) + routineRepository.countByCategory(findCategory);
 
         if (count == 0) {
             categoryRepository.deleteByUserAndId(user, removeCategoryRequest.getCategoryId());

--- a/BE/src/test/java/com/newsainturtle/shadowmate/yn/planner_setting/PlannerSettingServiceTest.java
+++ b/BE/src/test/java/com/newsainturtle/shadowmate/yn/planner_setting/PlannerSettingServiceTest.java
@@ -272,10 +272,11 @@ class PlannerSettingServiceTest extends DateCommonService {
 
 
             @Test
-            void 성공_카테고리_할일에없음() {
+            void 성공_카테고리_할일에없음_루틴에없음() {
                 //given
                 doReturn(category).when(categoryRepository).findByUserAndId(user, removeCategoryRequest.getCategoryId());
                 doReturn(0L).when(todoRepository).countByCategory(category);
+                doReturn(0L).when(routineRepository).countByCategory(category);
 
                 //when
                 plannerSettingService.removeCategory(user, removeCategoryRequest);
@@ -285,14 +286,16 @@ class PlannerSettingServiceTest extends DateCommonService {
                 //verify
                 verify(categoryRepository, times(1)).findByUserAndId(any(), any(Long.class));
                 verify(todoRepository, times(1)).countByCategory(any(Category.class));
+                verify(routineRepository, times(1)).countByCategory(any(Category.class));
                 verify(categoryRepository, times(1)).deleteByUserAndId(any(), any(Long.class));
             }
 
             @Test
-            void 성공_카테고리_할일에있음() {
+            void 성공_카테고리_할일에없음_루틴에있음() {
                 //given
                 doReturn(category).when(categoryRepository).findByUserAndId(user, removeCategoryRequest.getCategoryId());
-                doReturn(1L).when(todoRepository).countByCategory(category);
+                doReturn(0L).when(todoRepository).countByCategory(category);
+                doReturn(1L).when(routineRepository).countByCategory(category);
 
                 //when
                 plannerSettingService.removeCategory(user, removeCategoryRequest);
@@ -302,6 +305,43 @@ class PlannerSettingServiceTest extends DateCommonService {
                 //verify
                 verify(categoryRepository, times(1)).findByUserAndId(any(), any(Long.class));
                 verify(todoRepository, times(1)).countByCategory(any(Category.class));
+                verify(routineRepository, times(1)).countByCategory(any(Category.class));
+            }
+
+            @Test
+            void 성공_카테고리_할일에있음_루틴에없음() {
+                //given
+                doReturn(category).when(categoryRepository).findByUserAndId(user, removeCategoryRequest.getCategoryId());
+                doReturn(1L).when(todoRepository).countByCategory(category);
+                doReturn(0L).when(routineRepository).countByCategory(category);
+
+                //when
+                plannerSettingService.removeCategory(user, removeCategoryRequest);
+
+                //then
+
+                //verify
+                verify(categoryRepository, times(1)).findByUserAndId(any(), any(Long.class));
+                verify(todoRepository, times(1)).countByCategory(any(Category.class));
+                verify(routineRepository, times(1)).countByCategory(any(Category.class));
+            }
+
+            @Test
+            void 성공_카테고리_할일에있음_루틴에있음() {
+                //given
+                doReturn(category).when(categoryRepository).findByUserAndId(user, removeCategoryRequest.getCategoryId());
+                doReturn(1L).when(todoRepository).countByCategory(category);
+                doReturn(1L).when(routineRepository).countByCategory(category);
+
+                //when
+                plannerSettingService.removeCategory(user, removeCategoryRequest);
+
+                //then
+
+                //verify
+                verify(categoryRepository, times(1)).findByUserAndId(any(), any(Long.class));
+                verify(todoRepository, times(1)).countByCategory(any(Category.class));
+                verify(routineRepository, times(1)).countByCategory(any(Category.class));
             }
         }
     }

--- a/BE/src/test/java/com/newsainturtle/shadowmate/yn/planner_setting/repository/RoutineRepositoryTest.java
+++ b/BE/src/test/java/com/newsainturtle/shadowmate/yn/planner_setting/repository/RoutineRepositoryTest.java
@@ -1,6 +1,10 @@
 package com.newsainturtle.shadowmate.yn.planner_setting.repository;
 
+import com.newsainturtle.shadowmate.planner_setting.entity.Category;
+import com.newsainturtle.shadowmate.planner_setting.entity.CategoryColor;
 import com.newsainturtle.shadowmate.planner_setting.entity.Routine;
+import com.newsainturtle.shadowmate.planner_setting.repository.CategoryColorRepository;
+import com.newsainturtle.shadowmate.planner_setting.repository.CategoryRepository;
 import com.newsainturtle.shadowmate.planner_setting.repository.RoutineRepository;
 import com.newsainturtle.shadowmate.user.entity.User;
 import com.newsainturtle.shadowmate.user.enums.PlannerAccessScope;
@@ -26,6 +30,12 @@ class RoutineRepositoryTest {
 
     @Autowired
     private UserRepository userRepository;
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @Autowired
+    private CategoryColorRepository categoryColorRepository;
 
     private User user;
     private final String startDay = "2023-12-25";
@@ -163,6 +173,58 @@ class RoutineRepositoryTest {
 
         //then
         assertThat(findRoutine).isNull();
+    }
+
+    @Nested
+    class 해당카테고리가있는루틴_카운트 {
+        @Test
+        void 루틴없음() {
+            //given
+            final CategoryColor categoryColor = categoryColorRepository.findById(1L).orElse(null);
+            final Category category = categoryRepository.save(Category.builder()
+                    .id(1L)
+                    .categoryColor(categoryColor)
+                    .user(user)
+                    .categoryTitle("국어")
+                    .categoryRemove(false)
+                    .categoryEmoticon("🍅")
+                    .build());
+
+            //when
+            final long count = routineRepository.countByCategory(category);
+
+            //then
+            assertThat(count).isZero();
+        }
+
+        @Test
+        void 루틴있음() {
+            //given
+            final CategoryColor categoryColor = categoryColorRepository.findById(1L).orElse(null);
+            final Category category = categoryRepository.save(Category.builder()
+                    .id(1L)
+                    .categoryColor(categoryColor)
+                    .user(user)
+                    .categoryTitle("국어")
+                    .categoryRemove(false)
+                    .categoryEmoticon("🍅")
+                    .build());
+            routineRepository.save(Routine.builder()
+                    .startDay(startDay)
+                    .endDay(endDay)
+                    .routineContent(routineContent)
+                    .category(category)
+                    .user(user)
+                    .routineDays(new ArrayList<>())
+                    .routineTodos(new ArrayList<>())
+                    .build());
+
+            //when
+            final long count = routineRepository.countByCategory(category);
+
+            //then
+            assertThat(count).isEqualTo(1);
+        }
     }
 
 }


### PR DESCRIPTION
close #628

## 어떤 이유로 MR를 하셨나요?

- [x] test 코드 작성
- [x] feature 병합
- [ ] 버그 수정
- [ ] 코드 개선
- [ ] 기타(아래에 자세한 내용 기입해주세요)

## 세부 내용 - 왜 해당 MR이 필요한지 자세하게 설명해주세요

- 카테고리 삭제 시 등록된 루틴 중에 해당 카테고리를 사용하는지 확인하는 로직을 추가했습니다.
- 요청, 응답 형식은 동일하기 때문에 프론트 측에서는 수정할 부분은 없습니다!😄

## MR하기 전에 확인해주세요

- [x] 커밋 컨벤션을 맞췄나요?
- [x] 오류나는 코드는 없나요?
