### PR TITLE
[BE] 할일 삭제 시 관련된 루틴할일 데이터 삭제

### DIFF
--- a/BE/src/main/java/com/newsainturtle/shadowmate/planner/service/DailyPlannerServiceImpl.java
+++ b/BE/src/main/java/com/newsainturtle/shadowmate/planner/service/DailyPlannerServiceImpl.java
@@ -18,7 +18,9 @@ import com.newsainturtle.shadowmate.planner.repository.DailyPlannerRepository;
 import com.newsainturtle.shadowmate.planner.repository.TimeTableRepository;
 import com.newsainturtle.shadowmate.planner.repository.TodoRepository;
 import com.newsainturtle.shadowmate.planner_setting.entity.Category;
+import com.newsainturtle.shadowmate.planner_setting.entity.RoutineTodo;
 import com.newsainturtle.shadowmate.planner_setting.repository.CategoryRepository;
+import com.newsainturtle.shadowmate.planner_setting.repository.RoutineTodoRepository;
 import com.newsainturtle.shadowmate.social.entity.Social;
 import com.newsainturtle.shadowmate.social.repository.SocialRepository;
 import com.newsainturtle.shadowmate.user.entity.User;
@@ -43,6 +45,7 @@ public class DailyPlannerServiceImpl extends DateCommonService implements DailyP
     private final TimeTableRepository timeTableRepository;
     private final UserRepository userRepository;
     private final SocialRepository socialRepository;
+    private final RoutineTodoRepository routineTodoRepository;
 
     private DailyPlanner getOrCreateDailyPlanner(final User user, final String date) {
         DailyPlanner dailyPlanner = dailyPlannerRepository.findByUserAndDailyPlannerDay(user, date);
@@ -149,6 +152,11 @@ public class DailyPlannerServiceImpl extends DateCommonService implements DailyP
     public void removeDailyTodo(final User user, final RemoveDailyTodoRequest removeDailyTodoRequest) {
         final DailyPlanner dailyPlanner = getDailyPlanner(user, removeDailyTodoRequest.getDate());
         final Todo todo = getTodo(removeDailyTodoRequest.getTodoId(), dailyPlanner);
+        final RoutineTodo routineTodo = routineTodoRepository.findByTodo(todo);
+        if(routineTodo != null){
+            routineTodo.setRoutine(null);
+            routineTodoRepository.deleteById(routineTodo.getId());
+        }
         todoRepository.deleteById(todo.getId());
     }
 

--- a/BE/src/main/java/com/newsainturtle/shadowmate/planner_setting/repository/RoutineTodoRepository.java
+++ b/BE/src/main/java/com/newsainturtle/shadowmate/planner_setting/repository/RoutineTodoRepository.java
@@ -1,5 +1,6 @@
 package com.newsainturtle.shadowmate.planner_setting.repository;
 
+import com.newsainturtle.shadowmate.planner.entity.Todo;
 import com.newsainturtle.shadowmate.planner_setting.entity.Routine;
 import com.newsainturtle.shadowmate.planner_setting.entity.RoutineTodo;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -14,6 +15,8 @@ public interface RoutineTodoRepository extends JpaRepository<RoutineTodo, Long> 
     RoutineTodo[] findAllByRoutineAndTodoIsNullAndDailyPlannerDayLessThanEqual(final Routine routine, final String dailyPlannerDay);
     RoutineTodo[] findAllByRoutineAndTodoIsNotNull(final Routine routine);
     RoutineTodo[] findAllByRoutineAndTodoIsNotNullAndDailyPlannerDayAfter(final Routine routine, final String dailyPlannerDay);
+    RoutineTodo findByTodo(final Todo todo);
+
 
     @Query("SELECT rt FROM RoutineTodo rt LEFT JOIN fetch Routine r on rt.routine.id = r.id where r.user.id = :userId and rt.dailyPlannerDay = :dailyPlannerDay and rt.todo is null")
     RoutineTodo[] findAllByUserAndDailyPlannerDayAndTodoIsNull(@Param("userId") final Long userId, @Param("dailyPlannerDay") final String dailyPlannerDay);

--- a/BE/src/test/java/com/newsainturtle/shadowmate/yn/planner_setting/repository/RoutineTodoRepositoryTest.java
+++ b/BE/src/test/java/com/newsainturtle/shadowmate/yn/planner_setting/repository/RoutineTodoRepositoryTest.java
@@ -437,4 +437,50 @@ class RoutineTodoRepositoryTest {
         }
     }
 
+    @Nested
+    class 해당할일에관련된_루틴할일조회 {
+        @Test
+        void 데이터없음() {
+            //given
+            final Todo todo = todoRepository.save(Todo.builder()
+                    .category(null)
+                    .todoContent("수능완성 수학 과목별 10문제")
+                    .todoStatus(TodoStatus.EMPTY)
+                    .dailyPlanner(dailyPlanner)
+                    .todoIndex(100000D)
+                    .timeTables(new ArrayList<>())
+                    .build());
+
+            //when
+            final RoutineTodo routineTodo = routineTodoRepository.findByTodo(todo);
+
+            //then
+            assertThat(routineTodo).isNull();
+        }
+
+        @Test
+        void 데이터있음() {
+            //given
+            final Todo todo = todoRepository.save(Todo.builder()
+                    .category(null)
+                    .todoContent("수능완성 수학 과목별 10문제")
+                    .todoStatus(TodoStatus.EMPTY)
+                    .dailyPlanner(dailyPlanner)
+                    .todoIndex(100000D)
+                    .timeTables(new ArrayList<>())
+                    .build());
+            routineTodoRepository.save(RoutineTodo.builder()
+                    .todo(todo)
+                    .dailyPlannerDay("2023-12-25")
+                    .day("월")
+                    .build()).setRoutine(routine);
+
+            //when
+            final RoutineTodo routineTodo = routineTodoRepository.findByTodo(todo);
+
+            //then
+            assertThat(routineTodo).isNotNull();
+        }
+    }
+
 }


### PR DESCRIPTION
close #627

## 어떤 이유로 MR를 하셨나요?

- [x] test 코드 작성
- [x] feature 병합
- [ ] 버그 수정
- [ ] 코드 개선
- [ ] 기타(아래에 자세한 내용 기입해주세요)

## 세부 내용 - 왜 해당 MR이 필요한지 자세하게 설명해주세요

- 할일 삭제 시 관련된 루틴-할일 데이터가 있는지 확인하고 함께 삭제하는 로직을 추가했습니다.
- 요청, 응답 형식은 동일하기 때문에 프론트 측에서는 수정할 부분은 없습니다!🙂

## MR하기 전에 확인해주세요

- [x] 커밋 컨벤션을 맞췄나요?
- [x] 오류나는 코드는 없나요?
