### PR TITLE
[FE] 할 일 순서 이동 제한 설정

### DIFF
--- a/FE/src/components/planner/day/todo/TodoItem.tsx
+++ b/FE/src/components/planner/day/todo/TodoItem.tsx
@@ -20,9 +20,13 @@ interface Props {
     deleteTodo: (idx: number, todoId: number) => void;
     deleteTimeTable: (todoId: number, timeTables: TimeTableConfig[], todoStatus: TodoConfig["todoStatus"]) => void;
   };
+  dragModule?: {
+    childMouseEnter: () => void;
+    childMouseLeave: () => void;
+  };
 }
 
-const TodoItem = ({ idx = -1, todoItem, addTodo, disable, todoModule }: Props) => {
+const TodoItem = ({ idx = -1, todoItem, addTodo, disable, todoModule, dragModule }: Props) => {
   const { todoContent, todoStatus } = todoItem;
   const category = (() => todoItem.category ?? BASIC_CATEGORY_ITEM)();
   const { categoryTitle, categoryColorCode } = category;
@@ -176,7 +180,10 @@ const TodoItem = ({ idx = -1, todoItem, addTodo, disable, todoModule }: Props) =
 
             {!addTodo && (
               <div className={styles["todo-item__content__icons"]}>
-                <div onClick={(e) => e.stopPropagation()}>
+                <div
+                  onMouseEnter={() => dragModule?.childMouseEnter()}
+                  onMouseLeave={() => dragModule?.childMouseLeave()}
+                >
                   <DragHandle />
                 </div>
                 <div

--- a/FE/src/components/planner/day/todo/TodoList.tsx
+++ b/FE/src/components/planner/day/todo/TodoList.tsx
@@ -100,7 +100,7 @@ const TodoList = ({ clicked }: Props) => {
   })();
 
   const dragHoverStyle = styles["todo-draggable"];
-  const { containerDragOver, dragStart, dragEnter, dragEnd } = dragModule({
+  const { containerDragOver, dragStart, dragEnter, dragEnd, ...childMouseEvent } = dragModule({
     date,
     todos: copyTodos,
     setTodos,
@@ -129,7 +129,7 @@ const TodoList = ({ clicked }: Props) => {
                 onDragLeave={(e) => e.preventDefault()}
                 onDragEnd={(e) => dragEnd(e, item.todoId)}
               >
-                <TodoItem idx={idx} todoItem={item} todoModule={todoModule} />
+                <TodoItem idx={idx} todoItem={item} todoModule={todoModule} dragModule={childMouseEvent} />
               </div>
             ))}
           </div>

--- a/FE/src/styles/planner/day.module.scss
+++ b/FE/src/styles/planner/day.module.scss
@@ -435,7 +435,7 @@ $color-btn-blue: var(--color-btn-blue);
       display: flex;
       gap: 0.5em;
       > div:first-child {
-        cursor: s-resize;
+        cursor: grab;
       }
     }
   }

--- a/FE/src/styles/planner/day.module.scss
+++ b/FE/src/styles/planner/day.module.scss
@@ -435,7 +435,7 @@ $color-btn-blue: var(--color-btn-blue);
       display: flex;
       gap: 0.5em;
       > div:first-child {
-        cursor: grab;
+        cursor: s-resize;
       }
     }
   }

--- a/FE/src/util/DragModule.ts
+++ b/FE/src/util/DragModule.ts
@@ -57,8 +57,12 @@ const dragModule = ({ date, todos, setTodos, dragClassName, draggablesRef }: Pro
     const copyTodos = [...todos];
     const drageTargetIdx = dragTargetRef.current;
     const endTargetIdx = dragEndRef.current;
-    const upperTodoId = endTargetIdx > 0 ? copyTodos[endTargetIdx].todoId : null;
     if (drageTargetIdx == endTargetIdx || endTargetIdx == -1) return;
+    const upperTodoId = (() => {
+      if (endTargetIdx == 0) return null;
+      if (drageTargetIdx > endTargetIdx) return copyTodos[endTargetIdx - 1].todoId;
+      return copyTodos[endTargetIdx].todoId;
+    })();
 
     await plannerApi
       .todoSequence(userId, {

--- a/FE/src/util/DragModule.ts
+++ b/FE/src/util/DragModule.ts
@@ -1,4 +1,4 @@
-import { DragEvent, MutableRefObject } from "react";
+import { DragEvent, MutableRefObject, useState } from "react";
 import { plannerApi } from "@api/Api";
 import { Dispatch, SetStateAction, useRef } from "react";
 import { TodoConfig } from "./planner.interface";
@@ -19,6 +19,9 @@ const dragModule = ({ date, todos, setTodos, dragClassName, draggablesRef }: Pro
   const userId = useAppSelector(selectUserId);
   const dragTargetRef = useRef<number>(0);
   const dragEndRef = useRef<number>(0);
+  const [mouseOnChild, setMouseOnChild] = useState(false);
+  const childMouseEnter = () => setMouseOnChild(true);
+  const childMouseLeave = () => setMouseOnChild(false);
 
   const containerDragOver = (e: DragEvent<HTMLDivElement>) => {
     e.preventDefault();
@@ -28,6 +31,11 @@ const dragModule = ({ date, todos, setTodos, dragClassName, draggablesRef }: Pro
   };
 
   const dragStart = (e: DragEvent<HTMLDivElement>, idx: number) => {
+    if (!mouseOnChild) {
+      e.preventDefault();
+      e.stopPropagation();
+      return;
+    }
     e.dataTransfer.setDragImage(new Image(), 0, 0);
     e.currentTarget.classList.add(dragClassName);
     dragTargetRef.current = idx;
@@ -85,6 +93,8 @@ const dragModule = ({ date, todos, setTodos, dragClassName, draggablesRef }: Pro
   };
 
   return {
+    childMouseEnter,
+    childMouseLeave,
     containerDragOver,
     dragStart,
     dragEnter,

--- a/FE/src/util/DragModule.ts
+++ b/FE/src/util/DragModule.ts
@@ -17,8 +17,8 @@ interface Props {
 
 const dragModule = ({ date, todos, setTodos, dragClassName, draggablesRef }: Props) => {
   const userId = useAppSelector(selectUserId);
-  const dragTargetRef = useRef<number>(0);
-  const dragEndRef = useRef<number>(0);
+  const dragTargetRef = useRef<number>(-1);
+  const dragEndRef = useRef<number>(-1);
   const [mouseOnChild, setMouseOnChild] = useState(false);
   const childMouseEnter = () => setMouseOnChild(true);
   const childMouseLeave = () => setMouseOnChild(false);
@@ -58,6 +58,7 @@ const dragModule = ({ date, todos, setTodos, dragClassName, draggablesRef }: Pro
     const drageTargetIdx = dragTargetRef.current;
     const endTargetIdx = dragEndRef.current;
     const upperTodoId = endTargetIdx > 0 ? copyTodos[endTargetIdx].todoId : null;
+    if (drageTargetIdx == endTargetIdx || endTargetIdx == -1) return;
 
     await plannerApi
       .todoSequence(userId, {
@@ -69,8 +70,8 @@ const dragModule = ({ date, todos, setTodos, dragClassName, draggablesRef }: Pro
         const dragItemContent = copyTodos[drageTargetIdx];
         copyTodos.splice(drageTargetIdx, 1);
         copyTodos.splice(endTargetIdx, 0, dragItemContent);
-        dragTargetRef.current = 0;
-        dragEndRef.current = 0;
+        dragTargetRef.current = -1;
+        dragEndRef.current = -1;
         setTodos(copyTodos);
       });
   };


### PR DESCRIPTION
close #626 

## 어떤 이유로 MR를 하셨나요?

- [ ] test 코드 작성
- [x] feature 병합
- [ ] 버그 수정
- [ ] 코드 개선
- [ ] 기타(아래에 자세한 내용 기입해주세요)

## 세부 내용 - 왜 해당 MR이 필요한지 자세하게 설명해주세요

-  할 일 순서 이동 제한 로직 추가
   - useState로 dragStart 가능 여부 판별
- 일별 플래너 아이콘으로만 할 일 이동 가능하게 하기
- 할일 순서 제자리 이동일 때 API 호출 제한
- 할일 순서 위로 이동시 upperTodoId 잘 못 보내는 버그 해결

## MR하기 전에 확인해주세요

- [x] 커밋 컨벤션을 맞췄나요?
- [x] 오류나는 코드는 없나요?
